### PR TITLE
Fixed a bug with av_free missing by adding a proper include.

### DIFF
--- a/src/usb_cam.cpp
+++ b/src/usb_cam.cpp
@@ -54,6 +54,7 @@ extern "C" {
 #include <linux/videodev2.h>
 #include <libavcodec/avcodec.h>
 #include <libswscale/swscale.h>
+#include <libavutil/mem.h>
 }
 
 #include <ros/ros.h>


### PR DESCRIPTION
Problem exists when compiling from source on Ubuntu 14.04
