### PR TITLE
add a a ros::spinOnce to get set_camera_info working

### DIFF
--- a/nodes/usb_cam_node.cpp
+++ b/nodes/usb_cam_node.cpp
@@ -179,6 +179,7 @@ public:
         ROS_ERROR("couldn't take image.");
         usleep(1000000);
       }
+      ros::spinOnce();
 //      self_test_.checkTest();
     }
     return true;


### PR DESCRIPTION
This is explained in the docs of CameraInfoManager
https://github.com/ros-perception/image_common/blob/hydro-devel/camera_info_manager/include/camera_info_manager/camera_info_manager.h#L71
Also, this fixes https://github.com/ros-perception/image_pipeline/issues/78
