### PR TITLE
Renamed deprecated CODEC_ID to AV_CODEC_ID to fix compilation for libav 10

### DIFF
--- a/src/usb_cam.cpp
+++ b/src/usb_cam.cpp
@@ -387,7 +387,7 @@ static int init_mjpeg_decoder(int image_width, int image_height)
 {
   avcodec_register_all();
 
-  avcodec = avcodec_find_decoder(CODEC_ID_MJPEG);
+  avcodec = avcodec_find_decoder(AV_CODEC_ID_MJPEG);
   if (!avcodec)
   {
     ROS_ERROR("Could not find MJPEG decoder\n");
@@ -400,7 +400,7 @@ static int init_mjpeg_decoder(int image_width, int image_height)
 
   avpicture_alloc((AVPicture *)avframe_rgb, PIX_FMT_RGB24, image_width, image_height);
 
-  avcodec_context->codec_id = CODEC_ID_MJPEG;
+  avcodec_context->codec_id = AV_CODEC_ID_MJPEG;
   avcodec_context->width = image_width;
   avcodec_context->height = image_height;
 


### PR DESCRIPTION
The library is now used in Ubuntu Utopic 14.10 and the constants have been deprecated for a long time:
https://wiki.libav.org/Migration/10
