### PR TITLE
do not modify parameters unless explicitly set

### DIFF
--- a/nodes/usb_cam_node.cpp
+++ b/nodes/usb_cam_node.cpp
@@ -68,10 +68,10 @@ public:
 
     // grab the parameters
     node_.param("video_device", video_device_name_, std::string("/dev/video0"));
-    node_.param("brightness", brightness_, 128); //0-255
-    node_.param("contrast", contrast_, 32); //0-255
-    node_.param("saturation", saturation_, 32); //0-255
-    node_.param("sharpness", sharpness_, 22); //0-255
+    node_.param("brightness", brightness_, -1); //0-255, -1 "leave alone"
+    node_.param("contrast", contrast_, -1); //0-255, -1 "leave alone"
+    node_.param("saturation", saturation_, -1); //0-255, -1 "leave alone"
+    node_.param("sharpness", sharpness_, -1); //0-255, -1 "leave alone"
     // possible values: mmap, read, userptr
     node_.param("io_method", io_method_name_, std::string("mmap"));
     node_.param("image_width", image_width_, 640);
@@ -81,7 +81,7 @@ public:
     node_.param("pixel_format", pixel_format_name_, std::string("mjpeg"));
     // enable/disable autofocus
     node_.param("autofocus", autofocus_, false);
-    node_.param("focus", focus_, 51);
+    node_.param("focus", focus_, -1); //0-255, -1 "leave alone"
     // enable/disable autoexposure
     node_.param("autoexposure", autoexposure_, true);
     node_.param("exposure", exposure_, 100);
@@ -138,17 +138,32 @@ public:
 
     // set camera parameters
     std::stringstream paramstream;
-    paramstream << "brightness=" << brightness_;
-    this->set_v4l_parameters(video_device_name_, paramstream.str());
-    paramstream.str("");
-    paramstream << "contrast=" << contrast_;
-    this->set_v4l_parameters(video_device_name_, paramstream.str());
-    paramstream.str("");
-    paramstream << "saturation=" << saturation_;
-    this->set_v4l_parameters(video_device_name_, paramstream.str());
-    paramstream.str("");
-    paramstream << "sharpness=" << sharpness_;
-    this->set_v4l_parameters(video_device_name_, paramstream.str());
+    if (brightness_ >= 0)
+    {
+      paramstream << "brightness=" << brightness_;
+      this->set_v4l_parameters(video_device_name_, paramstream.str());
+      paramstream.str("");
+    }
+
+    if (contrast_ >= 0)
+    {
+      paramstream << "contrast=" << contrast_;
+      this->set_v4l_parameters(video_device_name_, paramstream.str());
+      paramstream.str("");
+    }
+
+    if (saturation_ >= 0)
+    {
+      paramstream << "saturation=" << saturation_;
+      this->set_v4l_parameters(video_device_name_, paramstream.str());
+      paramstream.str("");
+    }
+
+    if (sharpness_ >= 0)
+    {
+      paramstream << "sharpness=" << sharpness_;
+      this->set_v4l_parameters(video_device_name_, paramstream.str());
+    }
 
     // check auto white balance
     if (auto_white_balance_)
@@ -183,9 +198,11 @@ public:
     else
     {
       this->set_v4l_parameters(video_device_name_, "focus_auto=0");
-      std::stringstream ss;
-      ss << "focus_absolute=" << focus_;
-      this->set_v4l_parameters(video_device_name_, ss.str());
+      if (focus_ >= 0) {
+        std::stringstream ss;
+        ss << "focus_absolute=" << focus_;
+        this->set_v4l_parameters(video_device_name_, ss.str());
+      }
     }
   }
 


### PR DESCRIPTION
The contrast, saturation, brightness, sharpness and focus parameters were recently added to usb_cam in b25c293. This caused a regression for us (sigproc/robotic_surgery#17) whereby, unless reset explicitly, the default settings for a webcam are overridden in all cases by the hard-coded defaults in usb_cam. This caused a previously working setup to start behaving very strangely.

It's probably near impossible to find a set of "known good" defaults for all cameras and so this PR changes the behaviour of the node to simply avoid setting the contrast, saturation, etc unless they've been explicitly set in the launch file. This is an application of the "principle of least surprise".
