### PR TITLE
Warn rather than error if framerate can't be set

### DIFF
--- a/src/usb_cam.cpp
+++ b/src/usb_cam.cpp
@@ -953,7 +953,7 @@ static void init_device(int image_width, int image_height, int framerate)
   stream_params.parm.capture.timeperframe.numerator = 1;
   stream_params.parm.capture.timeperframe.denominator = framerate;
   if (xioctl(fd, VIDIOC_S_PARM, &stream_params) < 0)
-    errno_exit("Couldn't set camera framerate\n");
+    ROS_WARN("Couldn't set camera framerate\n");
   else
     ROS_DEBUG("Set framerate to be %i", framerate);
 


### PR DESCRIPTION
The driver doesn't currently work with em28xx based devices as they don't allow the framerate to be set directly and the node exits with an error. Changing to a warning allows these devices to be used.
