### PR TITLE
Changes for ROS Kinetic, fix build warnings and verbosity.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -10,6 +10,7 @@ find_package(catkin REQUIRED COMPONENTS image_transport roscpp std_msgs std_srvs
 find_package(PkgConfig REQUIRED)
 pkg_check_modules(avcodec libavcodec REQUIRED)
 pkg_check_modules(swscale libswscale REQUIRED)
+pkg_check_modules(avutil libavutil REQUIRED)
 
 ###################################################
 ## Declare things to be passed to other projects ##
@@ -27,10 +28,12 @@ catkin_package(
 ## Build ##
 ###########
 
-include_directories(include
+include_directories(
+  include
   ${catkin_INCLUDE_DIRS}
   ${avcodec_INCLUDE_DIRS}
   ${swscale_INCLUDE_DIRS}
+  ${avutil_INCLUDE_DIRS}
 )
 
 ## Build the USB camera library
@@ -48,6 +51,7 @@ target_link_libraries(${PROJECT_NAME}_node
   ${avcodec_LIBRARIES}
   ${swscale_LIBRARIES}
   ${catkin_LIBRARIES}
+  ${avutil_LIBRARIES}
 )
 
 #############

--- a/nodes/usb_cam_node.cpp
+++ b/nodes/usb_cam_node.cpp
@@ -40,6 +40,7 @@
 #include <camera_info_manager/camera_info_manager.h>
 #include <sstream>
 #include <std_srvs/Empty.h>
+#include <libavutil/log.h>
 
 namespace usb_cam {
 
@@ -268,6 +269,7 @@ public:
 
 int main(int argc, char **argv)
 {
+  av_log_set_level(AV_LOG_ERROR);
   ros::init(argc, argv, "usb_cam");
   usb_cam::UsbCamNode a;
   a.spin();

--- a/src/usb_cam.cpp
+++ b/src/usb_cam.cpp
@@ -449,7 +449,6 @@ void UsbCam::mjpeg2rgb(char *MJPEG, int len, char *RGB, int NumPixels)
   video_sws_ = sws_getContext(xsize, ysize, avcodec_context_->pix_fmt, xsize, ysize, PIX_FMT_RGB24, SWS_BILINEAR, NULL,
 			      NULL,  NULL);
 
-  av_log_set_level(AV_LOG_ERROR);
   sws_scale(video_sws_, avframe_camera_->data, avframe_camera_->linesize, 0, ysize, avframe_rgb_->data,
             avframe_rgb_->linesize);
   sws_freeContext(video_sws_);

--- a/src/usb_cam.cpp
+++ b/src/usb_cam.cpp
@@ -54,6 +54,7 @@
 
 #include <usb_cam/usb_cam.h>
 
+
 #define CLEAR(x) memset (&(x), 0, sizeof (x))
 
 namespace usb_cam {
@@ -375,8 +376,13 @@ int UsbCam::init_mjpeg_decoder(int image_width, int image_height)
   }
 
   avcodec_context_ = avcodec_alloc_context3(avcodec_);
+#if LIBAVCODEC_VERSION_MAJOR > 52
+  avframe_camera_ = av_frame_alloc();
+  avframe_rgb_ = av_frame_alloc();
+#else
   avframe_camera_ = avcodec_alloc_frame();
   avframe_rgb_ = avcodec_alloc_frame();
+#endif
 
   avpicture_alloc((AVPicture *)avframe_rgb_, PIX_FMT_RGB24, image_width, image_height);
 
@@ -442,6 +448,8 @@ void UsbCam::mjpeg2rgb(char *MJPEG, int len, char *RGB, int NumPixels)
 
   video_sws_ = sws_getContext(xsize, ysize, avcodec_context_->pix_fmt, xsize, ysize, PIX_FMT_RGB24, SWS_BILINEAR, NULL,
 			      NULL,  NULL);
+
+  av_log_set_level(AV_LOG_ERROR);
   sws_scale(video_sws_, avframe_camera_->data, avframe_camera_->linesize, 0, ysize, avframe_rgb_->data,
             avframe_rgb_->linesize);
   sws_freeContext(video_sws_);


### PR DESCRIPTION
Minor changes to make build and runtime less verbose. I added a call to avutil log_level to set the log level to error instead of warnings to avoid warnings about deprecated pixel formats that aren't meant for end users.
