### PR TITLE
Fix double free.

### DIFF
--- a/nodes/usb_cam_node.cpp
+++ b/nodes/usb_cam_node.cpp
@@ -223,7 +223,6 @@ public:
 
   virtual ~UsbCamNode()
   {
-    cam_.shutdown();
   }
 
   bool take_and_send_image()


### PR DESCRIPTION
UsbCam::uninit_device() was called in UsbCam::~UsbCam() and also in UsbCamNode::~UsbCamNode().
This invoked double free of UsbCam::buffers_.