### PR TITLE
Use v4l2_buffer timestamp when available

### DIFF
--- a/include/usb_cam/usb_cam.h
+++ b/include/usb_cam/usb_cam.h
@@ -104,6 +104,7 @@ class UsbCam {
     int height;
     int bytes_per_pixel;
     int image_size;
+    ros::Time stamp;
     char *image;
     int is_new;
   } camera_image_t;

--- a/src/usb_cam.cpp
+++ b/src/usb_cam.cpp
@@ -1084,7 +1084,7 @@ void UsbCam::grab_image(sensor_msgs::Image* msg)
   // grab the image
   grab_image();
   // stamp the image
-  msg->header.stamp = ros::Time::now();
+  msg->header.stamp = image_->stamp;
   // fill the info
   if (monochrome_)
   {
@@ -1112,6 +1112,7 @@ void UsbCam::grab_image()
   tv.tv_usec = 0;
 
   r = select(fd_ + 1, &fds, NULL, NULL, &tv);
+  image_->stamp = ros::Time::now();
 
   if (-1 == r)
   {


### PR DESCRIPTION
The v4l2_buffer timestamp is much more accurate than taking the current ros time after transferring the image.

For #75 