### PR TITLE
Add Nodelet functionality

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -4,7 +4,10 @@ project(usb_cam)
 ## Find catkin macros and libraries
 ## if COMPONENTS list like find_package(catkin REQUIRED COMPONENTS xyz)
 ## is used, also find other catkin packages
-find_package(catkin REQUIRED COMPONENTS image_transport roscpp std_msgs std_srvs sensor_msgs camera_info_manager)
+find_package(catkin REQUIRED COMPONENTS image_transport roscpp std_msgs std_srvs sensor_msgs camera_info_manager nodelet)
+
+# Use C++11
+set(CMAKE_CXX_FLAGS "--std=c++11 ${CMAKE_CXX_FLAGS}")
 
 ## pkg-config libraries
 find_package(PkgConfig REQUIRED)
@@ -41,6 +44,15 @@ target_link_libraries(${PROJECT_NAME}
   ${catkin_LIBRARIES}
 )
 
+## Build USB camera nodelet library
+add_library(${PROJECT_NAME}_nodelet nodes/usb_cam_nodelet.cpp)
+target_link_libraries(${PROJECT_NAME}_nodelet
+  ${PROJECT_NAME}
+  ${avcodec_LIBRARIES}
+  ${swscale_LIBRARIES}
+  ${catkin_LIBRARIES}
+)
+
 ## Declare a cpp executable
 add_executable(${PROJECT_NAME}_node nodes/usb_cam_node.cpp)
 target_link_libraries(${PROJECT_NAME}_node
@@ -55,9 +67,14 @@ target_link_libraries(${PROJECT_NAME}_node
 #############
 
 ## Mark executables and/or libraries for installation
-install(TARGETS ${PROJECT_NAME}_node ${PROJECT_NAME}
+install(TARGETS ${PROJECT_NAME}_node ${PROJECT_NAME} ${PROJECT_NAME}_nodelet
   RUNTIME DESTINATION ${CATKIN_PACKAGE_BIN_DESTINATION}
   LIBRARY DESTINATION ${CATKIN_PACKAGE_LIB_DESTINATION}
+)
+
+# Copy xml files
+install(FILES package.xml nodelet_plugins.xml
+    DESTINATION ${CATKIN_PACKAGE_SHARE_DESTINATION}
 )
 
 ## Copy launch files

--- a/include/usb_cam/usb_cam.h
+++ b/include/usb_cam/usb_cam.h
@@ -42,6 +42,7 @@ extern "C"
 {
 #include <linux/videodev2.h>
 #include <libavcodec/avcodec.h>
+#include <libavutil/imgutils.h>
 #include <libswscale/swscale.h>
 #include <libavutil/mem.h>
 }

--- a/launch/nodelet.launch
+++ b/launch/nodelet.launch
@@ -1,0 +1,19 @@
+<launch>
+  <arg name="manager" value="nodelet_manager" />
+
+  <node pkg="nodelet" type="nodelet" name="$(arg manager)" args="manager" output="screen" />
+
+  <node pkg="nodelet" type="nodelet" name="usb_cam"
+           args="load usb_cam/UsbCamNodelet $(arg manager)" output="screen" >
+    <param name="video_device" value="/dev/video0" />
+    <param name="image_width" value="640" />
+    <param name="image_height" value="480" />
+    <param name="pixel_format" value="yuyv" />
+    <param name="camera_frame_id" value="usb_cam" />
+    <param name="io_method" value="mmap"/>
+  </node>
+  <node name="image_view" pkg="image_view" type="image_view" respawn="false" output="screen">
+    <remap from="image" to="/usb_cam/image_raw"/>
+    <param name="autosize" value="true" />
+  </node>
+</launch>

--- a/launch/nodelet.launch
+++ b/launch/nodelet.launch
@@ -5,7 +5,7 @@
 
   <node pkg="nodelet" type="nodelet" name="usb_cam"
            args="load usb_cam/UsbCamNodelet $(arg manager)" output="screen" >
-    <param name="video_device" value="/dev/video0" />
+    <param name="video_device" value="/dev/video1" />
     <param name="image_width" value="640" />
     <param name="image_height" value="480" />
     <param name="pixel_format" value="yuyv" />

--- a/launch/nodelet.launch
+++ b/launch/nodelet.launch
@@ -5,7 +5,7 @@
 
   <node pkg="nodelet" type="nodelet" name="usb_cam"
            args="load usb_cam/UsbCamNodelet $(arg manager)" output="screen" >
-    <param name="video_device" value="/dev/video1" />
+    <param name="video_device" value="/dev/video0" />
     <param name="image_width" value="640" />
     <param name="image_height" value="480" />
     <param name="pixel_format" value="yuyv" />

--- a/nodelet_plugins.xml
+++ b/nodelet_plugins.xml
@@ -1,0 +1,7 @@
+<library path="lib/libusb_cam_nodelet">
+    <class name="usb_cam/UsbCamNodelet"
+           type="usb_cam::UsbCamNodelet"
+           base_class_type="nodelet::Nodelet">
+        <description>Nodelet implementation of ROS driver for V4L USB cameras</description>
+    </class>
+</library>

--- a/nodes/usb_cam_nodelet.cpp
+++ b/nodes/usb_cam_nodelet.cpp
@@ -1,0 +1,340 @@
+#include <cstdlib>
+
+#include <mutex>
+#include <sstream>
+#include <thread>
+
+#include <camera_info_manager/camera_info_manager.h>
+#include <image_transport/image_transport.h>
+#include <nodelet/nodelet.h>
+#include <nodelet/NodeletUnload.h>
+#include <pluginlib/class_list_macros.h>
+#include <ros/ros.h>
+#include <std_srvs/SetBool.h>
+#include <system_error>
+
+#include <usb_cam/usb_cam.h>
+
+#define SHUTDOWN_NODELET() \
+NODELET_FATAL_ONCE("Unloading nodelet"); \
+nodelet::NodeletUnload unload_service; \
+unload_service.request.name = getName(); \
+if (!ros::service::call(ros::this_node::getName() + "/unload_nodelet", unload_service)) { \
+    ros::shutdown(); \
+}
+
+namespace usb_cam
+{
+static const std::string DEFAULT_CAMERA_NAME = "head_camera";
+
+static const std::string DEFAULT_VIDEO_DEVICE = "/dev/video0";
+static const std::string DEFAULT_IO_METHOD = "mmap";
+static const std::string DEFAULT_PIXEL_FORMAT = "mjpeg";
+
+static const int DEFAULT_IMAGE_HEIGHT = 480;
+static const int DEFAULT_IMAGE_WIDTH = 640;
+
+static const int DEFAULT_FRAMERATE = 30;
+
+static const int DEFAULT_EXPOSURE = 100;
+
+static const int DEFAULT_WHITE_BALANCE = 4000;
+
+static const bool DEFAULT_AUTO_FOCUS_STATE = false;
+static const bool DEFAULT_AUTO_EXPOSURE_STATE = true;
+static const bool DEFAULT_AUTO_WHITE_BALANCE_STATE = true;
+
+static const int AUTOMATIC = -1;
+
+class UsbCamNodelet : public nodelet::Nodelet
+{
+public:
+    UsbCamNodelet() :
+            img_(new sensor_msgs::Image())
+    {
+
+    }
+
+    void onInit()
+    {
+        ros::NodeHandle nh = getPrivateNodeHandle();
+
+        image_transport::ImageTransport it(nh);
+
+        image_pub_ = it.advertiseCamera("image_raw", 1);
+
+        load_from_parameters_(nh);
+
+        cinfo_.reset(new camera_info_manager::CameraInfoManager(nh, camera_name_, camera_info_url_));
+
+        if (!cinfo_->isCalibrated())
+        {
+            recalibrate_camera_info_();
+        }
+
+        NODELET_INFO("Starting '%s' (%s) at %dx%d via %s (%s) at %i FPS",
+                     camera_name_.c_str(), video_device_name_.c_str(), image_width_, image_height_,
+                     io_method_name_.c_str(), pixel_format_name_.c_str(), framerate_);
+
+        UsbCam::io_method io_method = UsbCam::io_method_from_string(io_method_name_);
+        if(io_method == UsbCam::IO_METHOD_UNKNOWN)
+        {
+            NODELET_FATAL("Unknown IO method '%s'", io_method_name_.c_str());
+            SHUTDOWN_NODELET();
+            return;
+        }
+
+        UsbCam::pixel_format pixel_format = UsbCam::pixel_format_from_string(pixel_format_name_);
+        if (pixel_format == UsbCam::PIXEL_FORMAT_UNKNOWN)
+        {
+            NODELET_FATAL("Unknown pixel format '%s'", pixel_format_name_.c_str());
+            SHUTDOWN_NODELET();
+            return;
+        }
+
+        // only way to initialise our UsbCam, but we don't want to start capturing yet
+        cam_.start(video_device_name_.c_str(), io_method, pixel_format, image_width_,
+		               image_height_, framerate_);
+        cam_.stop_capturing();
+
+        set_v4l_params_();
+
+        service_toggle_capture_ = nh.advertiseService("toggle_capture", &UsbCamNodelet::service_toggle_cap, this);
+    }
+
+    virtual ~UsbCamNodelet()
+    {
+        service_toggle_capture_.shutdown();
+        std::unique_lock<std::mutex> cam_lock(cam_mutex_);
+        cam_.shutdown();
+        cam_lock.unlock();
+        if (publisher_thread_.joinable())
+        {
+            publisher_thread_.join();
+        }
+    }
+
+    bool service_toggle_cap(std_srvs::SetBool::Request & req, std_srvs::SetBool::Response & res)
+    {
+        if (req.data)
+        {
+            std::unique_lock<std::mutex> cam_lock(cam_mutex_);
+            if (!cam_.is_capturing())
+            {
+                // if capturing was recently stopped, we should wait for thread to finish execution
+                cam_lock.unlock();
+                try
+                {
+                    if (publisher_thread_.joinable())
+                    {
+                        publisher_thread_.join();
+                    }
+                    cam_lock.lock();
+                    cam_.start_capturing();
+                    publisher_thread_ = std::thread(&UsbCamNodelet::spin, this);
+                    res.success = true;
+                }
+                catch (const std::system_error & e)
+                {
+                    NODELET_ERROR("Couldn't start image publisher thread - %s", e.code().message().c_str());
+                }
+            }
+        }
+        else
+        {
+            std::lock_guard<std::mutex> cam_lock(cam_mutex_);
+            cam_.stop_capturing();
+            res.success = true;
+        }
+        return res.success;
+    }
+
+    void spin()
+    {
+        ros::Rate loop_rate(framerate_);
+        try
+        {
+            while (true)
+            {
+                std::unique_lock<std::mutex> cam_lock(cam_mutex_);
+                if (cam_.is_capturing())
+                {
+                    if (!take_and_send_image_()) {
+                        NODELET_WARN("USB camera did not respond in time.");
+                    }
+                }
+                else
+                {
+                    return;
+                }
+                cam_lock.unlock();
+                loop_rate.sleep();
+            }
+        }
+        catch (const std::exception & e)
+        {
+            NODELET_ERROR("Exception: %s", e.what());
+            return;
+        }
+    }
+
+private:
+    // Not thread-safe, called from spin()
+    bool take_and_send_image_()
+    {
+        cam_.grab_image(img_.get());
+
+        sensor_msgs::CameraInfoPtr ci(new sensor_msgs::CameraInfo(cinfo_->getCameraInfo()));
+        ci->header.frame_id = img_->header.frame_id;
+        ci->header.stamp = img_->header.stamp;
+
+        image_pub_.publish(img_, ci);
+
+        return true;
+    }
+
+    void load_from_parameters_(ros::NodeHandle & nh)
+    {
+        nh.param("video_device", video_device_name_, DEFAULT_VIDEO_DEVICE);
+        nh.param("brightness", brightness_, AUTOMATIC); //0-255
+        nh.param("contrast", contrast_, AUTOMATIC); //0-255
+        nh.param("saturation", saturation_, AUTOMATIC); //0-255
+        nh.param("sharpness", sharpness_, AUTOMATIC); //0-255
+        // possible values: mmap, read, userptr
+        nh.param("io_method", io_method_name_, DEFAULT_IO_METHOD);
+        nh.param("image_width", image_width_, DEFAULT_IMAGE_WIDTH);
+        nh.param("image_height", image_height_, DEFAULT_IMAGE_HEIGHT);
+        nh.param("framerate", framerate_, DEFAULT_FRAMERATE);
+        // possible values: yuyv, uyvy, mjpeg, yuvmono10, rgb24
+        nh.param("pixel_format", pixel_format_name_, DEFAULT_PIXEL_FORMAT);
+        // enable/disable autofocus
+        nh.param("autofocus", autofocus_, DEFAULT_AUTO_FOCUS_STATE);
+        nh.param("focus", focus_, AUTOMATIC); //0-255
+        // enable/disable autoexposure
+        nh.param("autoexposure", autoexposure_, DEFAULT_AUTO_EXPOSURE_STATE);
+        nh.param("exposure", exposure_, DEFAULT_EXPOSURE);
+        nh.param("gain", gain_, AUTOMATIC); //0-100?
+        // enable/disable auto white balance temperature
+        nh.param("auto_white_balance", auto_white_balance_, true);
+        nh.param("white_balance", white_balance_, DEFAULT_WHITE_BALANCE);
+
+        // load the camera info
+        nh.param("camera_frame_id", img_->header.frame_id, DEFAULT_CAMERA_NAME);
+        nh.param("camera_name", camera_name_, DEFAULT_CAMERA_NAME);
+        nh.param("camera_info_url", camera_info_url_, std::string());
+    }
+
+    void recalibrate_camera_info_()
+    {
+        sensor_msgs::CameraInfo calibration;
+        calibration.header.frame_id = img_->header.frame_id;
+        calibration.width = image_width_;
+        calibration.height = image_height_;
+
+        cinfo_->setCameraName(video_device_name_);
+        cinfo_->setCameraInfo(calibration);
+    }
+
+    // Not thread-safe, call before starting publisher_thread_
+    void set_v4l_params_()
+    {
+        if (brightness_ >= 0)
+        {
+            cam_.set_v4l_parameter("brightness", brightness_);
+        }
+
+        if (contrast_ >= 0)
+        {
+            cam_.set_v4l_parameter("contrast", contrast_);
+        }
+
+        if (saturation_ >= 0)
+        {
+            cam_.set_v4l_parameter("saturation", saturation_);
+        }
+
+        if (sharpness_ >= 0)
+        {
+            cam_.set_v4l_parameter("sharpness", sharpness_);
+        }
+
+        if (gain_ >= 0)
+        {
+            cam_.set_v4l_parameter("gain", gain_);
+        }
+
+        // check auto white balance
+        if (auto_white_balance_)
+        {
+            cam_.set_v4l_parameter("white_balance_temperature_auto", 1);
+        }
+        else
+        {
+            cam_.set_v4l_parameter("white_balance_temperature_auto", 0);
+            cam_.set_v4l_parameter("white_balance_temperature", white_balance_);
+        }
+
+        // check auto exposure
+        if (!autoexposure_)
+        {
+            // turn down exposure control (from max of 3)
+            cam_.set_v4l_parameter("exposure_auto", 1);
+            // change the exposure level
+            cam_.set_v4l_parameter("exposure_absolute", exposure_);
+        }
+
+        // check auto focus
+        if (autofocus_)
+        {
+            cam_.set_auto_focus(1);
+            cam_.set_v4l_parameter("focus_auto", 1);
+        }
+        else
+        {
+            cam_.set_v4l_parameter("focus_auto", 0);
+            if (focus_ >= 0)
+            {
+              cam_.set_v4l_parameter("focus_absolute", focus_);
+            }
+        }
+    }
+
+    sensor_msgs::ImagePtr img_;
+    image_transport::CameraPublisher image_pub_;
+
+    std::string video_device_name_;
+    std::string io_method_name_;
+    std::string pixel_format_name_;
+    std::string camera_name_;
+    std::string camera_info_url_;
+
+    bool streaming_status_;
+
+    int image_width_;
+    int image_height_;
+    int framerate_;
+    int exposure_;
+    int brightness_;
+    int contrast_;
+    int saturation_;
+    int sharpness_;
+    int focus_;
+    int white_balance_;
+    int gain_;
+
+    bool autofocus_;
+    bool autoexposure_;
+    bool auto_white_balance_;
+
+    boost::shared_ptr<camera_info_manager::CameraInfoManager> cinfo_;
+
+    UsbCam cam_;
+    std::mutex cam_mutex_;
+
+    ros::ServiceServer service_toggle_capture_;
+
+    std::thread publisher_thread_;
+};
+}
+
+PLUGINLIB_EXPORT_CLASS(usb_cam::UsbCamNodelet, nodelet::Nodelet);

--- a/nodes/usb_cam_nodelet.cpp
+++ b/nodes/usb_cam_nodelet.cpp
@@ -15,14 +15,6 @@
 
 #include <usb_cam/usb_cam.h>
 
-#define SHUTDOWN_NODELET() \
-NODELET_FATAL_ONCE("Unloading nodelet"); \
-nodelet::NodeletUnload unload_service; \
-unload_service.request.name = getName(); \
-if (!ros::service::call(ros::this_node::getName() + "/unload_nodelet", unload_service)) { \
-    ros::shutdown(); \
-}
-
 namespace usb_cam
 {
 static const std::string DEFAULT_CAMERA_NAME = "head_camera";
@@ -80,7 +72,6 @@ public:
         if(io_method_ == UsbCam::IO_METHOD_UNKNOWN)
         {
             NODELET_FATAL("Unknown IO method '%s'", io_method_name_.c_str());
-            SHUTDOWN_NODELET();
             return;
         }
 
@@ -88,7 +79,6 @@ public:
         if (pixel_format_ == UsbCam::PIXEL_FORMAT_UNKNOWN)
         {
             NODELET_FATAL("Unknown pixel format '%s'", pixel_format_name_.c_str());
-            SHUTDOWN_NODELET();
             return;
         }
 
@@ -149,6 +139,12 @@ public:
 
     void spin()
     {
+        if(io_method_ == UsbCam::IO_METHOD_UNKNOWN || pixel_format_ == UsbCam::PIXEL_FORMAT_UNKNOWN)
+        {
+            NODELET_ERROR("Unknown IO method % s or Pixel format %s", io_method_name_, pixel_format_name_);
+            return;
+        }
+
         ros::Rate loop_rate(framerate_);
         try
         {

--- a/nodes/usb_cam_nodelet.cpp
+++ b/nodes/usb_cam_nodelet.cpp
@@ -139,7 +139,9 @@ public:
         else
         {
             std::lock_guard<std::mutex> cam_lock(cam_mutex_);
-            cam_.shutdown();
+            if (cam_.is_capturing()) {
+                cam_.shutdown();
+            }
             res.success = true;
         }
         return res.success;

--- a/package.xml
+++ b/package.xml
@@ -14,20 +14,26 @@
 
   <buildtool_depend>catkin</buildtool_depend>
 
-  <build_depend>image_transport</build_depend> 
-  <build_depend>roscpp</build_depend> 
-  <build_depend>std_msgs</build_depend> 
-  <build_depend>std_srvs</build_depend> 
-  <build_depend>sensor_msgs</build_depend> 
+  <build_depend>image_transport</build_depend>
+  <build_depend>roscpp</build_depend>
+  <build_depend>std_msgs</build_depend>
+  <build_depend>std_srvs</build_depend>
+  <build_depend>sensor_msgs</build_depend>
   <build_depend>ffmpeg</build_depend>
   <build_depend>camera_info_manager</build_depend>
+  <build_depend>nodelet</build_depend>
 
-  <run_depend>image_transport</run_depend> 
-  <run_depend>roscpp</run_depend> 
-  <run_depend>std_msgs</run_depend> 
-  <run_depend>std_srvs</run_depend> 
-  <run_depend>sensor_msgs</run_depend> 
+  <run_depend>image_transport</run_depend>
+  <run_depend>roscpp</run_depend>
+  <run_depend>std_msgs</run_depend>
+  <run_depend>std_srvs</run_depend>
+  <run_depend>sensor_msgs</run_depend>
   <run_depend>ffmpeg</run_depend>
   <run_depend>camera_info_manager</run_depend>
   <run_depend>v4l-utils</run_depend>
+  <run_depend>nodelet</run_depend>
+
+  <export>
+      <nodelet plugin="${prefix}/nodelet_plugins.xml" />
+  </export>
 </package>

--- a/src/usb_cam.cpp
+++ b/src/usb_cam.cpp
@@ -375,22 +375,22 @@ int UsbCam::init_mjpeg_decoder(int image_width, int image_height)
   }
 
   avcodec_context_ = avcodec_alloc_context3(avcodec_);
-  avframe_camera_ = avcodec_alloc_frame();
-  avframe_rgb_ = avcodec_alloc_frame();
+  avframe_camera_ = av_frame_alloc();
+  avframe_rgb_ = av_frame_alloc();
 
-  avpicture_alloc((AVPicture *)avframe_rgb_, PIX_FMT_RGB24, image_width, image_height);
+  avpicture_alloc((AVPicture *)avframe_rgb_, AV_PIX_FMT_RGB24, image_width, image_height);
 
   avcodec_context_->codec_id = AV_CODEC_ID_MJPEG;
   avcodec_context_->width = image_width;
   avcodec_context_->height = image_height;
 
 #if LIBAVCODEC_VERSION_MAJOR > 52
-  avcodec_context_->pix_fmt = PIX_FMT_YUV422P;
+  avcodec_context_->pix_fmt = AV_PIX_FMT_YUV422P;
   avcodec_context_->codec_type = AVMEDIA_TYPE_VIDEO;
 #endif
 
-  avframe_camera_size_ = avpicture_get_size(PIX_FMT_YUV422P, image_width, image_height);
-  avframe_rgb_size_ = avpicture_get_size(PIX_FMT_RGB24, image_width, image_height);
+  avframe_camera_size_ = av_image_get_buffer_size(AV_PIX_FMT_YUV422P, image_width, image_height, 1);
+  avframe_rgb_size_ = av_image_get_buffer_size(AV_PIX_FMT_RGB24, image_width, image_height, 1);
 
   /* open it */
   if (avcodec_open2(avcodec_context_, avcodec_, &avoptions_) < 0)
@@ -440,13 +440,13 @@ void UsbCam::mjpeg2rgb(char *MJPEG, int len, char *RGB, int NumPixels)
     return;
   }
 
-  video_sws_ = sws_getContext(xsize, ysize, avcodec_context_->pix_fmt, xsize, ysize, PIX_FMT_RGB24, SWS_BILINEAR, NULL,
+  video_sws_ = sws_getContext(xsize, ysize, avcodec_context_->pix_fmt, xsize, ysize, AV_PIX_FMT_RGB24, SWS_BILINEAR, NULL,
 			      NULL,  NULL);
   sws_scale(video_sws_, avframe_camera_->data, avframe_camera_->linesize, 0, ysize, avframe_rgb_->data,
             avframe_rgb_->linesize);
   sws_freeContext(video_sws_);
 
-  int size = avpicture_layout((AVPicture *)avframe_rgb_, PIX_FMT_RGB24, xsize, ysize, (uint8_t *)RGB, avframe_rgb_size_);
+  int size = avpicture_layout((AVPicture *)avframe_rgb_, AV_PIX_FMT_RGB24, xsize, ysize, (uint8_t *)RGB, avframe_rgb_size_);
   if (size != avframe_rgb_size_)
   {
     ROS_ERROR("webcam: avpicture_layout error: %d", size);


### PR DESCRIPTION
This pull request includes a `usb_cam_nodelet`, which was developed to take advantage of zero-cost image transport between sibling Nodelets.

The Nodelet code is based off `usb_cam_node`, with the following main differences, besides defining a nodelet:

- This Nodelet won't automatically start publishing images when launched; you can call the `usb_cam/toggle_capture` service to start and stop the camera.
- Because the above service can be called at any time to stop the camera, there is a `cam_mutex_` to protect against reading from the camera when it is being stopped.

There are also some mostly cosmetic differences, such as named constants for the default configuration parameters etc.

Unfortunately, this pull request also includes a commit where I accounted for the latest libav versions, which I made before noticing [this commit from Daniel Seifert](https://github.com/ros-drivers/usb_cam/commit/00becba3b2286a928d2c2af9311fa9d8e3c23685), so there may be conflicts in that regard.

Please let me know what you think of the Nodelet implementation!

Thanks a lot! :)