### PR TITLE
Add support for cameras with hardware 'h264' encoding. 

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -8,7 +8,7 @@ find_package(catkin REQUIRED COMPONENTS image_transport roscpp std_msgs std_srvs
 
 ## pkg-config libraries
 find_package(PkgConfig REQUIRED)
-pkg_check_modules(avcodec libavcodec REQUIRED)
+pkg_check_modules(avcodec libavcodec libavutil REQUIRED)
 pkg_check_modules(swscale libswscale REQUIRED)
 
 ###################################################

--- a/include/usb_cam/usb_cam.h
+++ b/include/usb_cam/usb_cam.h
@@ -68,14 +68,20 @@ class UsbCam {
 
   typedef enum
   {
-    PIXEL_FORMAT_YUYV, PIXEL_FORMAT_UYVY, PIXEL_FORMAT_MJPEG, PIXEL_FORMAT_YUVMONO10, PIXEL_FORMAT_RGB24, PIXEL_FORMAT_GREY, PIXEL_FORMAT_UNKNOWN
+    PIXEL_FORMAT_YUYV, PIXEL_FORMAT_UYVY, PIXEL_FORMAT_MJPEG, PIXEL_FORMAT_YUVMONO10, PIXEL_FORMAT_RGB24, PIXEL_FORMAT_GREY, PIXEL_FORMAT_UNKNOWN,
+    PIXEL_FORMAT_H264,
   } pixel_format;
+
+  typedef enum
+  {
+    COLOR_FORMAT_YUV420P, COLOR_FORMAT_YUV422P, COLOR_FORMAT_UNKNOWN,
+  } color_format;
 
   UsbCam();
   ~UsbCam();
 
   // start camera
-  void start(const std::string& dev, io_method io, pixel_format pf,
+  void start(const std::string& dev, io_method io, pixel_format pf, color_format cf,
 		    int image_width, int image_height, int framerate);
   // shutdown camera
   void shutdown(void);
@@ -92,6 +98,7 @@ class UsbCam {
 
   static io_method io_method_from_string(const std::string& str);
   static pixel_format pixel_format_from_string(const std::string& str);
+  static color_format color_format_from_string(const std::string& str);
 
   void stop_capturing(void);
   void start_capturing(void);
@@ -115,7 +122,10 @@ class UsbCam {
   };
 
 
-  int init_mjpeg_decoder(int image_width, int image_height);
+  int init_decoder(int image_width, int image_height,
+      color_format color_format, AVCodecID codec_id, const char *codec_name);
+  int init_mjpeg_decoder(int image_width, int image_height, color_format color_format);
+  int init_h264_decoder(int image_width, int image_height, color_format color_format);
   void mjpeg2rgb(char *MJPEG, int len, char *RGB, int NumPixels);
   void process_image(const void * src, int len, camera_image_t *dest);
   int read_frame();

--- a/launch/usb_cam-test.launch
+++ b/launch/usb_cam-test.launch
@@ -4,6 +4,7 @@
     <param name="image_width" value="640" />
     <param name="image_height" value="480" />
     <param name="pixel_format" value="yuyv" />
+    <param name="color_format" value="yuv422p" />
     <param name="camera_frame_id" value="usb_cam" />
     <param name="io_method" value="mmap"/>
   </node>

--- a/nodes/usb_cam_node.cpp
+++ b/nodes/usb_cam_node.cpp
@@ -54,7 +54,7 @@ public:
   image_transport::CameraPublisher image_pub_;
 
   // parameters
-  std::string video_device_name_, io_method_name_, pixel_format_name_, camera_name_, camera_info_url_;
+  std::string video_device_name_, io_method_name_, pixel_format_name_, camera_name_, camera_info_url_, color_format_name_ ;
   //std::string start_service_name_, start_service_name_;
   bool streaming_status_;
   int image_width_, image_height_, framerate_, exposure_, brightness_, contrast_, saturation_, sharpness_, focus_,
@@ -101,6 +101,8 @@ public:
     node_.param("framerate", framerate_, 30);
     // possible values: yuyv, uyvy, mjpeg, yuvmono10, rgb24
     node_.param("pixel_format", pixel_format_name_, std::string("mjpeg"));
+    // possible values: yuv420p, yuv422p
+    node_.param("color_format", color_format_name_, std::string("yuv422p"));
     // enable/disable autofocus
     node_.param("autofocus", autofocus_, false);
     node_.param("focus", focus_, -1); //0-255, -1 "leave alone"
@@ -155,8 +157,17 @@ public:
       return;
     }
 
+    // set the color format
+    UsbCam::color_format color_format = UsbCam::color_format_from_string(color_format_name_);
+    if (color_format == UsbCam::COLOR_FORMAT_UNKNOWN)
+    {
+      ROS_FATAL("Unknown color format '%s'", color_format_name_.c_str());
+      node_.shutdown();
+      return;
+    }
+
     // start the camera
-    cam_.start(video_device_name_.c_str(), io_method, pixel_format, image_width_,
+    cam_.start(video_device_name_.c_str(), io_method, pixel_format, color_format, image_width_,
 		     image_height_, framerate_);
 
     // set camera parameters


### PR DESCRIPTION
Cameras like Mobius Maxi supports hardware 'h264' encoding and delivers higher fps at higher resolutions than 'yuyv' or 'mjpeg' pixel format.
Added support for `h264` in `pixel_format` parameter.
A new parameter `color_format` is introduced with possible values `yuv420p` and `yuv422p`, because some cameras like Mobius Maxi does not support `yuv422p` which is the default.