### PR TITLE
Suppress libav "deprecated pixel format used" mjpeg warnings

### DIFF
--- a/src/usb_cam.cpp
+++ b/src/usb_cam.cpp
@@ -375,6 +375,18 @@ int UsbCam::init_mjpeg_decoder(int image_width, int image_height)
   }
 
   avcodec_context_ = avcodec_alloc_context3(avcodec_);
+
+  // Suppress warnings of the following form:
+  //
+  // [swscaler @ 0x############] deprecated pixel format used, make sure you did set range correctly
+  //
+  // Or set this to AV_LOG_FATAL to additionally suppress occasional frame errors, e.g.:
+  //
+  // [mjpeg @ 0x############] overread 4
+  // [mjpeg @ 0x############] No JPEG data found in image
+  // [ERROR] [##########.##########]: Error while decoding frame.
+  av_log_set_level(AV_LOG_ERROR);
+	
 #if LIBAVCODEC_VERSION_MAJOR < 55
   avframe_camera_ = avcodec_alloc_frame();
   avframe_rgb_ = avcodec_alloc_frame();


### PR DESCRIPTION
Suppress warnings of the form:

```
[swscaler @ 0x############] deprecated pixel format used, make sure you did set range correctly
```

There are many reports of this, but see for example https://github.com/ros-drivers/usb_cam/issues/109 . 

This warning can be safely ignored at present. Long term libjpeg-turbo could be used instead of libav to decode mjpeg frames.