### PR TITLE
update package.xml to include image_transport_plugins

### DIFF
--- a/package.xml
+++ b/package.xml
@@ -23,6 +23,7 @@
   <depend>camera_info_manager</depend>
   <depend>builtin_interfaces</depend>
   <depend>image_transport</depend>
+  <depend>image_transport_plugins</depend>
   <depend>v4l-utils</depend>
 
   <depend>ffmpeg</depend>


### PR DESCRIPTION
by including this in the `package.xml` this should by default now enable the compressed image topics for this package.