### PR TITLE
Fix small warnings

### DIFF
--- a/include/usb_cam/usb_cam.hpp
+++ b/include/usb_cam/usb_cam.hpp
@@ -145,8 +145,6 @@ private:
   bool close_device(void);
   bool open_device(void);
   bool grab_image();
-  bool is_capturing_;
-
 
   rclcpp::Clock::SharedPtr clock_;
   std::string camera_dev_;
@@ -165,6 +163,7 @@ private:
   int avframe_rgb_size_;
   struct SwsContext * video_sws_;
   camera_image_t * image_;
+  bool is_capturing_;
 };
 
 }  // namespace usb_cam

--- a/include/usb_cam/usb_cam_utils.hpp
+++ b/include/usb_cam/usb_cam_utils.hpp
@@ -67,7 +67,7 @@ void monotonicToRealTime(const timespec & monotonic_time, timespec & real_time)
   }
 }
 
-static int xioctl(int fd, int request, void * arg)
+inline int xioctl(int fd, int request, void * arg)
 {
   int r;
 
@@ -245,7 +245,7 @@ const int clipping_table_offset = 128;
 /** Clip a value to the range 0<val<255. For speed this is done using an
  * array, so can only cope with numbers in the range -128<val<383.
  */
-static unsigned char CLIPVALUE(int val)
+inline unsigned char CLIPVALUE(int val)
 {
   // Old method (if)
   /*   val = val < 0 ? 0 : val; */
@@ -276,7 +276,7 @@ static unsigned char CLIPVALUE(int val)
  * [ B ]   [  1.0   2.041   0.002 ] [ V ]
  *
  */
-static bool YUV2RGB(
+inline bool YUV2RGB(
   const unsigned char y, const unsigned char u, const unsigned char v,
   unsigned char * r, unsigned char * g, unsigned char * b)
 {
@@ -326,7 +326,7 @@ bool uyvy2rgb(char * YUV, char * RGB, int NumPixels)
   return true;
 }
 
-static bool mono102mono8(char * RAW, char * MONO, int NumPixels)
+inline bool mono102mono8(char * RAW, char * MONO, int NumPixels)
 {
   int i, j;
   for (i = 0, j = 0; i < (NumPixels << 1); i += 2, j += 1) {
@@ -336,7 +336,7 @@ static bool mono102mono8(char * RAW, char * MONO, int NumPixels)
   return true;
 }
 
-static bool yuyv2rgb(char * YUV, char * RGB, int NumPixels)
+inline bool yuyv2rgb(char * YUV, char * RGB, int NumPixels)
 {
   int i, j;
   unsigned char y0, y1, u, v;

--- a/src/usb_cam.cpp
+++ b/src/usb_cam.cpp
@@ -123,7 +123,7 @@ bool UsbCam::mjpeg2rgb(char * MJPEG, int len, char * RGB, int NumPixels)
 {
   // RCLCPP_INFO_STREAM(
   //   rclcpp::get_logger("usb_cam"),
-  //     "mjpeg2rgb " << len << ", image 0x" << std::hex << (unsigned long int)RGB \
+  //     "mjpeg2rgb " << len << ", image 0x" << std::hex << (unsigned long int)RGB
   //     << std::dec << " " << NumPixels << ", avframe_rgb_size_ " << avframe_rgb_size_);
   int got_picture;
 
@@ -169,7 +169,7 @@ bool UsbCam::mjpeg2rgb(char * MJPEG, int len, char * RGB, int NumPixels)
 
   // TODO(lucasw) why does the image need to be scaled?  Does it also convert formats?
   // RCLCPP_INFO_STREAM(
-  //   rclcpp::get_logger("usb_cam"), "sw scaler " << xsize << " " << ysize << " " \
+  //   rclcpp::get_logger("usb_cam"), "sw scaler " << xsize << " " << ysize << " "
   //     << avcodec_context_->pix_fmt << ", linesize " << avframe_rgb_->linesize);
   #if 1
   avcodec_context_->pix_fmt = pix_fmt_backup;

--- a/src/usb_cam.cpp
+++ b/src/usb_cam.cpp
@@ -735,7 +735,7 @@ bool UsbCam::init_device(int image_width, int image_height, int framerate)
   RCLCPP_INFO_STREAM(
     rclcpp::get_logger("usb_cam"),
     "Capability flag: 0x" << std::hex << stream_params.parm.capture.capability << std::dec);
-  if (!stream_params.parm.capture.capability & V4L2_CAP_TIMEPERFRAME) {
+  if (!(stream_params.parm.capture.capability & V4L2_CAP_TIMEPERFRAME)) {
     RCLCPP_ERROR(rclcpp::get_logger("usb_cam"), "V4L2_CAP_TIMEPERFRAME not supported");
   }
 

--- a/src/usb_cam.cpp
+++ b/src/usb_cam.cpp
@@ -119,7 +119,7 @@ int UsbCam::init_mjpeg_decoder(int image_width, int image_height)
   return 1;
 }
 
-bool UsbCam::mjpeg2rgb(char * MJPEG, int len, char * RGB, int NumPixels)
+bool UsbCam::mjpeg2rgb(char * MJPEG, int len, char * RGB, int /* NumPixels */)
 {
   // RCLCPP_INFO_STREAM(
   //   rclcpp::get_logger("usb_cam"),

--- a/src/usb_cam.cpp
+++ b/src/usb_cam.cpp
@@ -1080,6 +1080,7 @@ bool UsbCam::set_v4l_parameter(const std::string & param, const std::string & va
   } else {
     RCLCPP_WARN(rclcpp::get_logger("usb_cam"), "usb_cam_node could not run '%s'", cmd.c_str());
   }
+  return true;
 }
 
 UsbCam::io_method UsbCam::io_method_from_string(const std::string & str)

--- a/src/usb_cam_node.cpp
+++ b/src/usb_cam_node.cpp
@@ -175,7 +175,7 @@ void UsbCamNode::get_params()
     } else if (parameter.get_name() == "video_device") {
       video_device_name_ = parameter.value_to_string();
     } else {
-      RCLCPP_WARN(this->get_logger(), "Invalid parameter name: %s", parameter.get_name());
+      RCLCPP_WARN(this->get_logger(), "Invalid parameter name: %s", parameter.get_name().c_str());
     }
   }
 }


### PR DESCRIPTION
I fixed some warnings.

I put the before/after results below.
**Note** There are some errors left, so I ignored some options.
```cmake
  add_compile_options(-Wall -Wextra -Wpedantic -Wno-overflow -Wno-deprecated-declarations -Wno-switch)
```

Before(aa937b786631f9633d504524d7b4a1060343190e)
```cmake
~/ghq/github.com/ros-drivers/usb_cam ros2*
❯ colcon build --symlink-install --cmake-args -DCMAKE_BUILD_TYPE=Release -DCMAKE_EXPORT_COMPILE_COMMANDS=ON 
Starting >>> usb_cam 
--- stderr: usb_cam                              
/home/kenji/ghq/github.com/ros-drivers/usb_cam/src/usb_cam.cpp:126:3: warning: multi-line comment [-Wcomment]
  126 |   //     "mjpeg2rgb " << len << ", image 0x" << std::hex << (unsigned long int)RGB \
      |   ^
/home/kenji/ghq/github.com/ros-drivers/usb_cam/src/usb_cam.cpp:172:3: warning: multi-line comment [-Wcomment]
  172 |   //   rclcpp::get_logger("usb_cam"), "sw scaler " << xsize << " " << ysize << " " \
      |   ^
In file included from /home/kenji/ghq/github.com/ros-drivers/usb_cam/src/usb_cam.cpp:31:
/home/kenji/ghq/github.com/ros-drivers/usb_cam/include/usb_cam/usb_cam.hpp: In constructor ‘usb_cam::UsbCam::UsbCam()’:
/home/kenji/ghq/github.com/ros-drivers/usb_cam/include/usb_cam/usb_cam.hpp:167:20: warning: ‘usb_cam::UsbCam::image_’ will be initialized after [-Wreorder]
  167 |   camera_image_t * image_;
      |                    ^~~~~~
/home/kenji/ghq/github.com/ros-drivers/usb_cam/include/usb_cam/usb_cam.hpp:148:8: warning:   ‘bool usb_cam::UsbCam::is_capturing_’ [-Wreorder]
  148 |   bool is_capturing_;
      |        ^~~~~~~~~~~~~
/home/kenji/ghq/github.com/ros-drivers/usb_cam/src/usb_cam.cpp:63:1: warning:   when initialized here [-Wreorder]
   63 | UsbCam::UsbCam()
      | ^~~~~~
/home/kenji/ghq/github.com/ros-drivers/usb_cam/src/usb_cam.cpp: In member function ‘bool usb_cam::UsbCam::mjpeg2rgb(char*, int, char*, int)’:
/home/kenji/ghq/github.com/ros-drivers/usb_cam/src/usb_cam.cpp:122:63: warning: unused parameter ‘NumPixels’ [-Wunused-parameter]
  122 | bool UsbCam::mjpeg2rgb(char * MJPEG, int len, char * RGB, int NumPixels)
      |                                                           ~~~~^~~~~~~~~
/home/kenji/ghq/github.com/ros-drivers/usb_cam/src/usb_cam.cpp: In member function ‘bool usb_cam::UsbCam::init_device(int, int, int)’:
/home/kenji/ghq/github.com/ros-drivers/usb_cam/src/usb_cam.cpp:738:7: warning: suggest parentheses around operand of ‘!’ or change ‘&’ to ‘&&’ or ‘!’ to ‘~’ [-Wparentheses]
  738 |   if (!stream_params.parm.capture.capability & V4L2_CAP_TIMEPERFRAME) {
      |       ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
/home/kenji/ghq/github.com/ros-drivers/usb_cam/src/usb_cam.cpp: In member function ‘bool usb_cam::UsbCam::set_v4l_parameter(const string&, const string&)’:
/home/kenji/ghq/github.com/ros-drivers/usb_cam/src/usb_cam.cpp:1083:1: warning: no return statement in function returning non-void [-Wreturn-type]
 1083 | }
      | ^
In file included from /opt/ros/galactic/include/rclcpp/client.hpp:40,
                 from /opt/ros/galactic/include/rclcpp/callback_group.hpp:23,
                 from /opt/ros/galactic/include/rclcpp/any_executable.hpp:20,
                 from /opt/ros/galactic/include/rclcpp/memory_strategy.hpp:25,
                 from /opt/ros/galactic/include/rclcpp/memory_strategies.hpp:18,
                 from /opt/ros/galactic/include/rclcpp/executor_options.hpp:20,
                 from /opt/ros/galactic/include/rclcpp/executor.hpp:36,
                 from /opt/ros/galactic/include/rclcpp/executors/multi_threaded_executor.hpp:26,
                 from /opt/ros/galactic/include/rclcpp/executors.hpp:21,
                 from /opt/ros/galactic/include/rclcpp/rclcpp.hpp:156,
                 from /home/kenji/ghq/github.com/ros-drivers/usb_cam/include/usb_cam/usb_cam.hpp:51,
                 from /home/kenji/ghq/github.com/ros-drivers/usb_cam/include/usb_cam/usb_cam_node.hpp:32,
                 from /home/kenji/ghq/github.com/ros-drivers/usb_cam/src/usb_cam_node.cpp:30:
/home/kenji/ghq/github.com/ros-drivers/usb_cam/src/usb_cam_node.cpp: In member function ‘void usb_cam::UsbCamNode::get_params()’:
/home/kenji/ghq/github.com/ros-drivers/usb_cam/src/usb_cam_node.cpp:178:39: warning: format ‘%s’ expects argument of type ‘char*’, but argument 5 has type ‘const string’ {aka ‘const std::__cxx11::basic_string<char>’} [-Wformat=]
  178 |       RCLCPP_WARN(this->get_logger(), "Invalid parameter name: %s", parameter.get_name());
      |                                       ^~~~~~~~~~~~~~~~~~~~~~~~~~~~
/home/kenji/ghq/github.com/ros-drivers/usb_cam/src/usb_cam_node.cpp:178:65: note: format string is defined here
  178 |       RCLCPP_WARN(this->get_logger(), "Invalid parameter name: %s", parameter.get_name());
      |                                                                ~^
      |                                                                 |
      |                                                                 char*
In file included from /home/kenji/ghq/github.com/ros-drivers/usb_cam/include/usb_cam/usb_cam.hpp:32,
                 from /home/kenji/ghq/github.com/ros-drivers/usb_cam/include/usb_cam/usb_cam_node.hpp:32,
                 from /home/kenji/ghq/github.com/ros-drivers/usb_cam/src/usb_cam_node.cpp:30:
/home/kenji/ghq/github.com/ros-drivers/usb_cam/include/usb_cam/usb_cam_utils.hpp: At global scope:
/home/kenji/ghq/github.com/ros-drivers/usb_cam/include/usb_cam/usb_cam_utils.hpp:339:13: warning: ‘bool usb_cam::yuyv2rgb(char*, char*, int)’ defined but not used [-Wunused-function]
  339 | static bool yuyv2rgb(char * YUV, char * RGB, int NumPixels)
      |             ^~~~~~~~
/home/kenji/ghq/github.com/ros-drivers/usb_cam/include/usb_cam/usb_cam_utils.hpp:329:13: warning: ‘bool usb_cam::mono102mono8(char*, char*, int)’ defined but not used [-Wunused-function]
  329 | static bool mono102mono8(char * RAW, char * MONO, int NumPixels)
      |             ^~~~~~~~~~~~
/home/kenji/ghq/github.com/ros-drivers/usb_cam/include/usb_cam/usb_cam_utils.hpp:70:12: warning: ‘int usb_cam::xioctl(int, int, void*)’ defined but not used [-Wunused-function]
   70 | static int xioctl(int fd, int request, void * arg)
      |            ^~~~~~
---
Finished <<< usb_cam [10.6s]

Summary: 1 package finished [10.7s]
  1 package had stderr output: usb_cam
```

After
```sh
~/ghq/github.com/ros-drivers/usb_cam fix-small-warnings*
❯ colcon build --symlink-install --cmake-args -DCMAKE_BUILD_TYPE=Release -DCMAKE_EXPORT_COMPILE_COMMANDS=ON 
Starting >>> usb_cam 
Finished <<< usb_cam [4.61s]                     

Summary: 1 package finished [4.72s]
```