### PR TITLE
[ros2] allow cameras that do not support setting format options via VIDIOC_S_FMT

### DIFF
--- a/include/usb_cam/usb_cam_utils.hpp
+++ b/include/usb_cam/usb_cam_utils.hpp
@@ -363,5 +363,18 @@ void rgb242rgb(char * YUV, char * RGB, int NumPixels)
 {
   memcpy(RGB, YUV, NumPixels * 3);
 }
+
+std::string fcc2s(unsigned int val)
+{
+	std::string s;
+
+	s += val & 0x7f;
+	s += (val >> 8) & 0x7f;
+	s += (val >> 16) & 0x7f;
+	s += (val >> 24) & 0x7f;
+	if (val & (1 << 31))
+		s += "-BE";
+	return s;
+}
 }  // namespace usb_cam
 #endif  // USB_CAM__USB_CAM_UTILS_HPP_

--- a/src/usb_cam.cpp
+++ b/src/usb_cam.cpp
@@ -692,12 +692,6 @@ bool UsbCam::init_device(int image_width, int image_height, int framerate)
 
   CLEAR(fmt);
 
-//  fmt.type = V4L2_BUF_TYPE_VIDEO_CAPTURE;
-//  fmt.fmt.pix.width = 640;
-//  fmt.fmt.pix.height = 480;
-//  fmt.fmt.pix.pixelformat = V4L2_PIX_FMT_YUYV;
-//  fmt.fmt.pix.field = V4L2_FIELD_INTERLACED;
-
   fmt.type = V4L2_BUF_TYPE_VIDEO_CAPTURE;
   fmt.fmt.pix.width = image_width;
   fmt.fmt.pix.height = image_height;
@@ -705,8 +699,34 @@ bool UsbCam::init_device(int image_width, int image_height, int framerate)
   fmt.fmt.pix.field = V4L2_FIELD_INTERLACED;
 
   if (-1 == xioctl(fd_, VIDIOC_S_FMT, &fmt)) {
-    std::cerr << "error, quitting, TODO throw " << errno << std::endl;
-    return false;  // ("VIDIOC_S_FMT");
+    /* Check if selected format is already active - some hardware e.g. droidcam do not support setting values via VIDIOC_S_FMT*/
+    CLEAR(fmt);
+
+    fmt.type = V4L2_BUF_TYPE_VIDEO_CAPTURE;
+
+    if (xioctl(fd_, VIDIOC_G_FMT, &fmt) >= 0) {
+      RCLCPP_ERROR_STREAM(
+          rclcpp::get_logger("usb_cam"),
+          camera_dev_ << " does not support setting format options.");
+      RCLCPP_ERROR_STREAM(
+          rclcpp::get_logger("usb_cam"),
+          camera_dev_ << " supports: \n \t Width/Height \t : "<<fmt.fmt.pix.width<<"/"<<fmt.fmt.pix.height<<"\n"
+                      <<"\t Pixel Format \t : "<<fcc2s(fmt.fmt.pix.pixelformat));
+
+      if(fmt.fmt.pix.pixelformat == pixelformat_ &&
+        fmt.fmt.pix.width == image_width &&
+        fmt.fmt.pix.height == image_height) {
+        RCLCPP_ERROR_STREAM(
+          rclcpp::get_logger("usb_cam"),
+          "Selected format '"<< fcc2s(fmt.fmt.pix.pixelformat) <<"' is the same as the camera supports. Starting node...");
+      } else {
+        std::cerr << "error, quitting, TODO throw " << errno << std::endl;
+        return false; // ("VIDIOC_S_FMT");
+      }
+    } else {
+      std::cerr << "error, quitting, TODO throw " << errno << std::endl;
+      return false;  // ("VIDIOC_S_FMT");
+    }
   }
 
   /* Note VIDIOC_S_FMT may change width and height. */


### PR DESCRIPTION
Some cameras, especially droidcam https://www.dev47apps.com/, do not support setting camera format parameters via v4l2 VIDIOC_S_FMT command. This changes will allow usage of this cameras if the selected pixelformat and width/height are the same as the camera supports.

This is a ros2 port of the PR https://github.com/ros-drivers/usb_cam/pull/126. I have not tested it so far.
