### PR TITLE
add a missing package to the list of dependencies

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -4,7 +4,7 @@ project(usb_cam)
 ## Find catkin macros and libraries
 ## if COMPONENTS list like find_package(catkin REQUIRED COMPONENTS xyz)
 ## is used, also find other catkin packages
-find_package(catkin REQUIRED COMPONENTS image_transport roscpp std_msgs std_srvs sensor_msgs camera_info_manager)
+find_package(catkin REQUIRED COMPONENTS image_transport roscpp std_msgs std_srvs sensor_msgs camera_info_manager image_view)
 
 ## pkg-config libraries
 find_package(PkgConfig REQUIRED)

--- a/package.xml
+++ b/package.xml
@@ -22,6 +22,7 @@
   <build_depend>sensor_msgs</build_depend> 
   <build_depend>ffmpeg</build_depend>
   <build_depend>camera_info_manager</build_depend>
+  <build_depend>image_view</build_depend>
 
   <run_depend>image_transport</run_depend> 
   <run_depend>roscpp</run_depend> 
@@ -31,4 +32,5 @@
   <run_depend>ffmpeg</run_depend>
   <run_depend>camera_info_manager</run_depend>
   <run_depend>v4l-utils</run_depend>
+  <run_depend>image_view</run_depend>
 </package>


### PR DESCRIPTION
usb_cam has a dependency on image_view package yet it wasn't listed in CMakeLists.txt. 

This is particularly a problem for ROS-Base: (Bare Bones). image_transport, camera_info_manager, and image_view don't get installed as part of ROS-Base, `catkin build usb_cam` warns the user about the lack of image_transport and camera_info_manager but not for image_view.