### PR TITLE
Enabled dynamic reconfiguration of usb_cam_node

### DIFF
--- a/include/usb_cam/usb_cam_node.hpp
+++ b/include/usb_cam/usb_cam_node.hpp
@@ -61,8 +61,12 @@ public:
 
   void init();
   void get_params();
+  void assign_params(const std::vector<rclcpp::Parameter> & parameters);
   void update();
   bool take_and_send_image();
+
+  rcl_interfaces::msg::SetParametersResult parametersCallback(
+    const std::vector<rclcpp::Parameter> & parameters);
 
   void service_capture(
     const std::shared_ptr<rmw_request_id_t> request_header,
@@ -101,6 +105,7 @@ public:
   rclcpp::TimerBase::SharedPtr timer_;
 
   rclcpp::Service<std_srvs::srv::SetBool>::SharedPtr service_capture_;
+  rclcpp::node_interfaces::OnSetParametersCallbackHandle::SharedPtr parameters_callback_handle_;
 };
 }  // namespace usb_cam
 #endif  // USB_CAM__USB_CAM_NODE_HPP_

--- a/src/usb_cam_node.cpp
+++ b/src/usb_cam_node.cpp
@@ -209,7 +209,7 @@ bool UsbCamNode::take_and_send_image()
 rcl_interfaces::msg::SetParametersResult UsbCamNode::parametersCallback(
   const std::vector<rclcpp::Parameter> & parameters)
 {
-  RCLCPP_INFO(get_logger(), "Callback called!");
+  RCLCPP_DEBUG(get_logger(), "Setting parameters for %s", camera_name_.c_str());
   timer_->reset();
   cam_.shutdown();
   assign_params(parameters);


### PR DESCRIPTION
This allows the parameters of the usb_cam_node to be dynamically adjustable using either `ros2 param set` or `rqt_reconfigure`.