### PR TITLE
Add H.264 support (ros2)

### DIFF
--- a/config/params.yaml
+++ b/config/params.yaml
@@ -5,6 +5,7 @@
       io_method: "mmap"
       frame_id: "camera"
       pixel_format: "yuyv"
+      color_format: "yuv422p"
       image_width: 640
       image_height: 480
       camera_name: "test_camera"

--- a/include/usb_cam/usb_cam.hpp
+++ b/include/usb_cam/usb_cam.hpp
@@ -78,6 +78,7 @@ public:
     PIXEL_FORMAT_YUVMONO10,
     PIXEL_FORMAT_RGB24,
     PIXEL_FORMAT_GREY,
+    PIXEL_FORMAT_H264,
     PIXEL_FORMAT_UNKNOWN
   } pixel_format;
 
@@ -133,6 +134,8 @@ private:
   };
 
 
+  int init_decoder(int image_width, int image_height, AVCodecID codec_id, const char *codec_name);
+  int init_h264_decoder(int image_width, int image_height);
   int init_mjpeg_decoder(int image_width, int image_height);
   bool mjpeg2rgb(char * MJPEG, int len, char * RGB, int NumPixels);
   bool process_image(const void * src, int len, camera_image_t * dest);

--- a/include/usb_cam/usb_cam.hpp
+++ b/include/usb_cam/usb_cam.hpp
@@ -82,12 +82,19 @@ public:
     PIXEL_FORMAT_UNKNOWN
   } pixel_format;
 
+  typedef enum
+  {
+    COLOR_FORMAT_YUV420P, 
+    COLOR_FORMAT_YUV422P, 
+    COLOR_FORMAT_UNKNOWN,
+  } color_format;
+
   UsbCam();
   ~UsbCam();
 
   // start camera
   bool start(
-    const std::string & dev, io_method io, pixel_format pf,
+    const std::string & dev, io_method io, pixel_format pf, color_format cf,
     uint32_t image_width, uint32_t image_height, int framerate);
   // shutdown camera
   bool shutdown(void);
@@ -109,6 +116,7 @@ public:
 
   static io_method io_method_from_string(const std::string & str);
   static pixel_format pixel_format_from_string(const std::string & str);
+  static color_format color_format_from_string(const std::string& str);
 
   bool stop_capturing(void);
   bool start_capturing(void);
@@ -134,9 +142,10 @@ private:
   };
 
 
-  int init_decoder(int image_width, int image_height, AVCodecID codec_id, const char *codec_name);
-  int init_h264_decoder(int image_width, int image_height);
-  int init_mjpeg_decoder(int image_width, int image_height);
+  int init_decoder(int image_width, int image_height, color_format color_format, 
+    AVCodecID codec_id, const char *codec_name);
+  int init_h264_decoder(int image_width, int image_height, color_format cf);
+  int init_mjpeg_decoder(int image_width, int image_height, color_format cf);
   bool mjpeg2rgb(char * MJPEG, int len, char * RGB, int NumPixels);
   bool process_image(const void * src, int len, camera_image_t * dest);
   bool read_frame();

--- a/include/usb_cam/usb_cam_node.hpp
+++ b/include/usb_cam/usb_cam_node.hpp
@@ -89,6 +89,7 @@ public:
   // to discover them,
   // or guvcview
   std::string pixel_format_name_;
+  std::string color_format_name_;
   int image_width_;
   int image_height_;
   int framerate_;


### PR DESCRIPTION
Inspired by #110 I added support for the `h264` pixel format and an alternative color format `yuv420p` to the ros2 version of this package.  

The `h264` mode can be enabled via the existing `pixel_format` parameter, while choosing the `yuv420p` can be done via the __new__ `color_format` parameter.  
The defaults were not modified.  

My motivation for this was to reduce the required CPU resources for the node with a H.264 enabled camera (Logitech C920).  
After testing it I noticed that compared to the MJPEG format the CPU usage wasn't much different (within 5%). I assume most of the processing takes place in the `process_image` step which is similar I guess.  
But you can probably provide  much more info here.  