### PR TITLE
update the deprecated decompression command

### DIFF
--- a/README.md
+++ b/README.md
@@ -97,7 +97,7 @@ The `usb_cam` should support compression by default since it uses `image_transpo
 Unfortunately `rviz2` and `show_image.py` do not support visualizing the compressed images just yet so you will need to republish the compressed image downstream to uncompress it:
 
 ```
-ros2 run image_transport republish compressed in/compressed:=image_raw/compressed raw out:=image_raw/uncompressed
+ros2 run image_transport republish compressed raw --ros-args --remap in/compressed:=image_raw/compressed --remap out:=image_raw/uncompressed
 ```
 
 #### Documentation


### PR DESCRIPTION
The current ros2 image decompression command produces the following warning because it is deprecated:
```
[WARN] [1662133933.155713605] [rcl]: Found remap rule 'in/compressed:=image_raw/compressed'. This syntax is deprecated. Use '--ros-args --remap in/compressed:=image_raw/compressed' instead.
[WARN] [1662133933.155877454] [rcl]: Found remap rule 'out:=image_raw/uncompressed'. This syntax is deprecated. Use '--ros-args --remap out:=image_raw/uncompressed' instead.
```

This change updates the decompression command to match the most recent ROS2 format.