### PR TITLE
Full support for last FFMPEG

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -36,8 +36,8 @@ include_directories(include
 ## Build the USB camera library
 add_library(${PROJECT_NAME} src/usb_cam.cpp)
 target_link_libraries(${PROJECT_NAME}
-  ${avcodec_LIBRARIES}
-  ${swscale_LIBRARIES}
+  ${avcodec_LINK_LIBRARIES}
+  ${swscale_LINK_LIBRARIES}
   ${catkin_LIBRARIES}
 )
 
@@ -45,8 +45,8 @@ target_link_libraries(${PROJECT_NAME}
 add_executable(${PROJECT_NAME}_node nodes/usb_cam_node.cpp)
 target_link_libraries(${PROJECT_NAME}_node
   ${PROJECT_NAME}
-  ${avcodec_LIBRARIES}
-  ${swscale_LIBRARIES}
+  ${avcodec_LINK_LIBRARIES}
+  ${swscale_LINK_LIBRARIES}
   ${catkin_LIBRARIES}
 )
 

--- a/include/usb_cam/usb_cam.h
+++ b/include/usb_cam/usb_cam.h
@@ -44,6 +44,7 @@ extern "C"
 #include <libavcodec/avcodec.h>
 #include <libswscale/swscale.h>
 #include <libavutil/mem.h>
+#include <libavutil/imgutils.h>
 }
 
 // legacy reasons


### PR DESCRIPTION
Old editions of `usb_cam` does not support the latest FFMPEG API calls, mainly `AVPicture` structures which are mostly both removed and declared deprecated in `libavcodec`. `AVPicture` API calls are now removed in favour of correct instantiation of `AVFrame` structures. The build process is also fixed (now the package is correctly built in isolated mode when compiled as a part of a customized ROS source bundle).

Tested on development FFMPEG `N-108445-ga1bfb5290e` and the latest release of version 5.1. Backward compatibility with version 4.2 also exists.