### PR TITLE
Full support for last FFMPEG

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -36,8 +36,8 @@ include_directories(include
 ## Build the USB camera library
 add_library(${PROJECT_NAME} src/usb_cam.cpp)
 target_link_libraries(${PROJECT_NAME}
-  ${avcodec_LIBRARIES}
-  ${swscale_LIBRARIES}
+  ${avcodec_LINK_LIBRARIES}
+  ${swscale_LINK_LIBRARIES}
   ${catkin_LIBRARIES}
 )
 
@@ -45,8 +45,8 @@ target_link_libraries(${PROJECT_NAME}
 add_executable(${PROJECT_NAME}_node nodes/usb_cam_node.cpp)
 target_link_libraries(${PROJECT_NAME}_node
   ${PROJECT_NAME}
-  ${avcodec_LIBRARIES}
-  ${swscale_LIBRARIES}
+  ${avcodec_LINK_LIBRARIES}
+  ${swscale_LINK_LIBRARIES}
   ${catkin_LIBRARIES}
 )
 

--- a/include/usb_cam/usb_cam.h
+++ b/include/usb_cam/usb_cam.h
@@ -44,6 +44,7 @@ extern "C"
 #include <libavcodec/avcodec.h>
 #include <libswscale/swscale.h>
 #include <libavutil/mem.h>
+#include <libavutil/imgutils.h>
 }
 
 // legacy reasons

--- a/src/usb_cam.cpp
+++ b/src/usb_cam.cpp
@@ -424,8 +424,9 @@ void UsbCam::mjpeg2rgb(char *MJPEG, int len, char *RGB, int NumPixels)
   AVPacket avpkt;
   av_init_packet(&avpkt);
 
-  avpkt.size = len;
-  avpkt.data = (unsigned char*)MJPEG;
+  //avpkt.size = len;
+  //avpkt.data = (unsigned char*)MJPEG;
+  av_packet_from_data (&avpkt, (unsigned char*)MJPEG, len);
   decoded_len = avcodec_send_packet(avcodec_context_, &avpkt);
   //decoded_len = avcodec_decode_video2(avcodec_context_, avframe_camera_, &got_picture, &avpkt);
   if (decoded_len < 0)
@@ -435,15 +436,18 @@ void UsbCam::mjpeg2rgb(char *MJPEG, int len, char *RGB, int NumPixels)
   }
 #else
   avcodec_decode_video(avcodec_context_, avframe_camera_, &got_picture, (uint8_t *) MJPEG, len);
-#endif
-
   if (!got_picture)
   {
     ROS_ERROR("Webcam: expected picture but didn't get it...");
     return;
   }
+#endif
   
-  avcodec_receive_frame(avcodec_context_, avframe_rgb_);
+  if (avcodec_receive_frame(avcodec_context_, avframe_camera_) < 0)
+  {
+    ROS_ERROR("Error while returning frame.");
+    return;
+  }
 
   int xsize = avcodec_context_->width;
   int ysize = avcodec_context_->height;
@@ -453,15 +457,16 @@ void UsbCam::mjpeg2rgb(char *MJPEG, int len, char *RGB, int NumPixels)
     ROS_ERROR("outbuf size mismatch.  pic_size: %d bufsize: %d", pic_size, avframe_camera_size_);
     return;
   }
+  //avframe_rgb_size_ = av_image_get_buffer_size(AV_PIX_FMT_RGB24, avcodec_context_->width, avcodec_context_->height, 32);
+  //unsigned char* frame_buffer = (uint8_t*)av_malloc(avframe_rgb_size_);
+  //av_image_fill_arrays(avframe_rgb_->data, avframe_rgb_->linesize, frame_buffer, AV_PIX_FMT_RGB24, avframe_rgb_->width, avframe_rgb_->height, 32);         
 
-  video_sws_ = sws_getContext(xsize, ysize, avcodec_context_->pix_fmt, xsize, ysize, AV_PIX_FMT_RGB24, SWS_BILINEAR, NULL,
-			      NULL,  NULL);
-  sws_scale(video_sws_, avframe_camera_->data, avframe_camera_->linesize, 0, ysize, avframe_rgb_->data,
-            avframe_rgb_->linesize);
+  video_sws_ = sws_getContext(xsize, ysize, avcodec_context_->pix_fmt, xsize, ysize, AV_PIX_FMT_RGB24, SWS_FAST_BILINEAR, NULL, NULL,  NULL);
+  sws_scale(video_sws_, avframe_camera_->data, avframe_camera_->linesize, 0, ysize, avframe_rgb_->data, avframe_rgb_->linesize);
   sws_freeContext(video_sws_);
-
+  
   //int size = avpicture_layout((AVPicture *)avframe_rgb_, AV_PIX_FMT_RGB24, xsize, ysize, (uint8_t *)RGB, avframe_rgb_size_);
-  int size = av_image_copy_to_buffer((uint8_t *)RGB, avframe_rgb_size_, avframe_rgb_->data, avframe_camera_->linesize, AV_PIX_FMT_RGB24, xsize, ysize, 32);
+  int size = av_image_copy_to_buffer((uint8_t *)RGB, avframe_rgb_size_, avframe_rgb_->data, avframe_rgb_->linesize, AV_PIX_FMT_RGB24, xsize, ysize, 32);
   if (size != avframe_rgb_size_)
   {
     ROS_ERROR("webcam: avpicture_layout error: %d", size);


### PR DESCRIPTION
Old editions of `usb_cam` does not support the latest FFMPEG API calls, mainly `AVPicture` structures which are mostly both removed and declared deprecated in `libavcodec`. `AVPicture` API calls are now removed in favour of correct instantiation of `AVFrame` structures. The build process is also fixed (now the package is correctly built in isolated mode when compiled as a part of a customized ROS source bundle).

Tested on development FFMPEG `N-108445-ga1bfb5290e` and the latest release of version 5.1. Backward compatibility with version 4.2 also exists.