### PR TITLE
Store and replay video streams

### DIFF
--- a/AUTHORS.md
+++ b/AUTHORS.md
@@ -17,4 +17,5 @@ Maintainers
   * [FriedCircuits](https://github.com/FriedCircuits)
   * [Ludovico Russo](https://github.com/ludusrusso)
   * [Benjamin Maidel](https://github.com/benmaidel)
+  * [Eric Price](https://github.com/corvuscorax)
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -42,9 +42,9 @@ include_directories(include
 ## Build the USB camera library
 add_library(${PROJECT_NAME} src/usb_cam.cpp)
 target_link_libraries(${PROJECT_NAME}
-  ${avcodec_LINK_LIBRARIES}
-  ${avutil_LINK_LIBRARIES}
-  ${swscale_LINK_LIBRARIES}
+  ${avcodec_LIBRARIES}
+  ${avutil_LIBRARIES}
+  ${swscale_LIBRARIES}
   ${catkin_LIBRARIES}
   ${OpenCV_LIBS}
 )
@@ -53,9 +53,9 @@ target_link_libraries(${PROJECT_NAME}
 add_executable(${PROJECT_NAME}_node nodes/usb_cam_node.cpp)
 target_link_libraries(${PROJECT_NAME}_node
   ${PROJECT_NAME}
-  ${avcodec_LINK_LIBRARIES}
-  ${avutil_LINK_LIBRARIES}
-  ${swscale_LINK_LIBRARIES}
+  ${avcodec_LIBRARIES}
+  ${avutil_LIBRARIES}
+  ${swscale_LIBRARIES}
   ${catkin_LIBRARIES}
   ${OpenCV_LIBS}
 )

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -60,12 +60,16 @@ target_link_libraries(${PROJECT_NAME}_node
   ${OpenCV_LIBS}
 )
 
+## Declare a c executable
+add_executable(streamcat src/streamcat.c)
+# only std libraries needed
+
 #############
 ## Install ##
 #############
 
 ## Mark executables and/or libraries for installation
-install(TARGETS ${PROJECT_NAME}_node ${PROJECT_NAME}
+install(TARGETS ${PROJECT_NAME}_node ${PROJECT_NAME} streamcat
   RUNTIME DESTINATION ${CATKIN_PACKAGE_BIN_DESTINATION}
   LIBRARY DESTINATION ${CATKIN_PACKAGE_LIB_DESTINATION}
 )

--- a/include/usb_cam/usb_cam.h
+++ b/include/usb_cam/usb_cam.h
@@ -156,6 +156,7 @@ class UsbCam {
   std::string camera_dev_;
   unsigned int pixelformat_;
   bool monochrome_;
+  bool camera_is_stream_dump_;
   io_method io_;
   int fd_;
   int streamdump_fd_;

--- a/include/usb_cam/usb_cam.h
+++ b/include/usb_cam/usb_cam.h
@@ -82,7 +82,7 @@ class UsbCam {
 
   // start camera
   void start(const std::string& dev, io_method io, pixel_format pf, color_format cf,
-		    int image_width, int image_height, int framerate);
+		    int image_width, int image_height, int framerate, const std::string& streamdump_file_name);
   // shutdown camera
   void shutdown(void);
 
@@ -102,6 +102,7 @@ class UsbCam {
 
   void stop_capturing(void);
   void start_capturing(void);
+  void set_recording(bool rec);
   bool is_capturing();
 
  private:
@@ -113,6 +114,8 @@ class UsbCam {
     int image_size;
     char *image;
     int is_new;
+    uint32_t sec;
+    uint32_t nsec;
   } camera_image_t;
 
   struct buffer
@@ -120,8 +123,17 @@ class UsbCam {
     void * start;
     size_t length;
   };
+  struct frame_header
+  {
+    size_t length;
+    uint32_t sec;
+    uint32_t nsec;
+    unsigned int pixelformat;
+    int width;
+    int height;
+  };
 
-
+   
   int init_decoder(int image_width, int image_height,
       color_format color_format, AVCodecID codec_id, const char *codec_name);
   int init_mjpeg_decoder(int image_width, int image_height, color_format color_format);
@@ -138,6 +150,7 @@ class UsbCam {
   void open_device(void);
   void grab_image();
   bool is_capturing_;
+  bool is_recording_;
 
 
   std::string camera_dev_;
@@ -145,6 +158,7 @@ class UsbCam {
   bool monochrome_;
   io_method io_;
   int fd_;
+  int streamdump_fd_;
   buffer * buffers_;
   unsigned int n_buffers_;
   AVFrame *avframe_camera_;

--- a/src/streamcat.c
+++ b/src/streamcat.c
@@ -1,0 +1,98 @@
+/*********************************************************************
+ *
+ * Software License Agreement (BSD License)
+ *
+ *  Copyright (c) 2022, Universität Stuttgart
+ *  All rights reserved.
+ *
+ *  Redistribution and use in source and binary forms, with or without
+ *  modification, are permitted provided that the following conditions
+ *  are met:
+ *
+ *   * Redistributions of source code must retain the above copyright
+ *     notice, this list of conditions and the following disclaimer.
+ *   * Redistributions in binary form must reproduce the above
+ *     copyright notice, this list of conditions and the following
+ *     disclaimer in the documentation and/or other materials provided
+ *     with the distribution.
+ *   * Neither the name of the Robert Bosch nor the names of its
+ *     contributors may be used to endorse or promote products derived
+ *     from this software without specific prior written permission.
+ *
+ *  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ *  "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ *  LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+ *  FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ *  COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+ *  INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+ *  BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ *  LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ *  CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ *  LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+ *  ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ *  POSSIBILITY OF SUCH DAMAGE.
+ *
+ *********************************************************************/
+
+#include <string.h>
+#include <stdio.h>
+#include <stdint.h>
+#include <stdlib.h>
+#include <unistd.h>
+#include <fcntl.h>
+
+struct frame_header
+{
+    size_t length;
+    uint32_t sec;
+    uint32_t nsec;
+    unsigned int pixelformat;
+    int width;
+    int height;
+};
+
+#define MAXSIZE (10000*10000*3)
+
+int main(int argc, char** argv) {
+
+    if (argc!=2 || strncmp(argv[argc-1],"--help",6)==0 || strncmp(argv[argc-1],"-h",2)==0) {
+        printf("Usage: %s <streamfile>\n",argv[0]);
+        printf("Reads the stream from <streamfile> and pipes it to STDOUT\n");
+        printf("Information is written to STDERR\n");
+        exit(0);
+    }
+    int fd=open(argv[1],O_RDONLY);
+    if (fd==-1) {
+        fprintf(stderr,"Error opening %s\n",argv[1]);
+        exit(1);
+    }
+
+    struct frame_header header;
+    int i=0;
+    char format[5]="XXXX";
+    char * buffer=malloc(MAXSIZE);
+    if (!buffer) {
+        fprintf(stderr,"Buffer MALLOC error!\n");
+        exit(1);
+    }
+    while (read(fd,&header,sizeof(header))==sizeof(header)) {
+        format[0]=(char)(header.pixelformat & 0xff);
+        format[1]=(char)((header.pixelformat>>8) & 0xff);
+        format[2]=(char)((header.pixelformat>>(2*8)) & 0xff);
+        format[3]=(char)((header.pixelformat>>(3*8)) & 0xff);
+        fprintf(stderr,"Frame %i: %ix%i at %i.%i fmt: %s, %lu bytes\n",i++,header.width,header.height,header.sec,header.nsec,format,header.length);
+        if (header.length>MAXSIZE) {
+            fprintf(stderr,"Error: Frame too large for buffer, maximum: %u\n",MAXSIZE);
+            exit(1);
+        }
+        if(read(fd,buffer,header.length)!=header.length) {
+            fprintf(stderr,"Read Error\n");
+            exit(1);
+        }
+        if(write(1,buffer,header.length)!=header.length) {
+            fprintf(stderr,"Write Error\n");
+            exit(1);
+        }
+    }
+    exit(0);
+}


### PR DESCRIPTION
Many webcams provide compressed streams. When video data is stored to disk it is also compressed.
A video driver that uncompresses data for ROS sensor_msgs/Image messages, and a second node that compresses it again to store video adds significant processing overhead, as video stream compression is expensive. This is undesirable especially on embedded robotic hardware.

It would be much more convenient to dump the already compressed stream into a file, and later replay that - as if it came from a camera. This makes it necessary to add frame headers to include metadata (such as ROS::Time stamps)

The modification in this branch/pull request make this possible. A parameter to the node specifies a filename in which the stream is to be stored. Recording can be turned on and off at any time - irrespective of whether the camera is capturing with a ROS message the node listens to.

Replaying the recorded stream can be done by using the file as a "video device"

To watch recorded streams, a separate script (written in C) - streamcat - pipes the stream to stdout, It can then be re-encoded with ffmpeg - streamed over the web, or watched with ffplay.

Recording adds a tiny bit of I/O overhead, but almost no CPU overhead, as existing buffers are used on the fly.

I'm happy to discuss modifications to this if desired.