### PR TITLE
263 check if specified pixel format is supported

### DIFF
--- a/config/params_2.yaml
+++ b/config/params_2.yaml
@@ -4,8 +4,8 @@
       framerate: 15.0
       io_method: "mmap"
       frame_id: "camera2"
-      pixel_format: "mjpeg2rgb"  # see usb_cam/supported_formats for list of supported formats
-            av_device_format: "YUV422P"
+      pixel_format: "mjpeg2rgb"
+      av_device_format: "YUV422P"
       image_width: 640
       image_height: 480
       camera_name: "test_camera2"

--- a/include/usb_cam/formats/av_pixel_format_helper.hpp
+++ b/include/usb_cam/formats/av_pixel_format_helper.hpp
@@ -960,6 +960,7 @@ inline AVPixelFormat get_av_pixel_format_from_string(const std::string & str)
   return STR_2_AVPIXFMT.find(fullFmtStr)->second;
 }
 
+
 /// @brief Get ROS PixelFormat from AVPixelFormat.
 /// @param avPixelFormat AVPixelFormat
 /// @return String specifying the ROS pixel format.
@@ -1032,6 +1033,17 @@ inline std::string get_ros_pixel_format_from_av_format(const AVPixelFormat & avP
   return ros_format;
 }
 
+
+/// @brief Overload to support av pixel formats being passed as strings
+/// @param avPixelFormat AvPixelFormat as string
+/// @return String specifying the ROS pixel format.
+inline std::string get_ros_pixel_format_from_av_format(const std::string avPixelFormatStr)
+{
+  auto fmt = get_av_pixel_format_from_string(avPixelFormatStr);
+  return get_ros_pixel_format_from_av_format(fmt);
+}
+
+
 /// @brief Get the number of channels from AVPixelFormat.
 /// @param avPixelFormat AVPixelFormat
 /// @return Number of channels as uint8
@@ -1074,6 +1086,17 @@ inline uint8_t get_channels_from_av_format(const AVPixelFormat & avPixelFormat)
   return channels;
 }
 
+
+/// @brief Overload of function below to support av pixel formats as strings
+/// @param avPixelFormatStr AvPixelFormat as string
+/// @return Number of channels as uint8_t
+inline uint8_t get_channels_from_av_format(const std::string & avPixelFormatStr)
+{
+  auto fmt = get_av_pixel_format_from_string(avPixelFormatStr);
+  return get_channels_from_av_format(fmt);
+}
+
+
 /// @brief Get the pixel bit depth from AVPixelFormat.
 /// @param avPixelFormat AVPixelFormat
 /// @return Bit depth as uint8
@@ -1104,6 +1127,16 @@ inline uint8_t get_bit_depth_from_av_format(const AVPixelFormat & avPixelFormat)
   }
 
   return bit_depth;
+}
+
+
+/// @brief Overload of function below to support passing av pixel formats as strings
+/// @param avPixelFormatStr AVPixelFormat as string
+/// @return Bit depth as uint8
+inline uint8_t get_bit_depth_from_av_format(const std::string & avPixelFormatStr)
+{
+  auto fmt = get_av_pixel_format_from_string(avPixelFormatStr);
+  return get_bit_depth_from_av_format(fmt);
 }
 
 }  // namespace formats

--- a/include/usb_cam/formats/m420.hpp
+++ b/include/usb_cam/formats/m420.hpp
@@ -46,7 +46,7 @@ namespace formats
 class M4202RGB : public pixel_format_base
 {
 public:
-  M4202RGB(const int & width, const int & height)
+  explicit M4202RGB(const format_arguments_t & args = format_arguments_t())
   : pixel_format_base(
       "m4202rgb",
       V4L2_PIX_FMT_M420,
@@ -54,8 +54,8 @@ public:
       3,
       8,
       true),
-    m_width(width),
-    m_height(height)
+    m_width(args.width),
+    m_height(args.height)
   {}
 
   /// @brief Convert a YUV420 (aka M420) image to RGB8

--- a/include/usb_cam/formats/mjpeg.hpp
+++ b/include/usb_cam/formats/mjpeg.hpp
@@ -63,22 +63,21 @@ namespace formats
 class RAW_MJPEG : public pixel_format_base
 {
 public:
-  explicit RAW_MJPEG(const AVPixelFormat & avDeviceFormat)
+  explicit RAW_MJPEG(const format_arguments_t & args = format_arguments_t())
   : pixel_format_base(
       "raw_mjpeg",
       V4L2_PIX_FMT_MJPEG,
-      get_ros_pixel_format_from_av_format(avDeviceFormat),
-      get_channels_from_av_format(avDeviceFormat),
-      get_bit_depth_from_av_format(avDeviceFormat),
+      get_ros_pixel_format_from_av_format(args.av_device_format_str),
+      get_channels_from_av_format(args.av_device_format_str),
+      get_bit_depth_from_av_format(args.av_device_format_str),
       false)
-  {
-  }
+  {}
 };
 
 class MJPEG2RGB : public pixel_format_base
 {
 public:
-  MJPEG2RGB(const int & width, const int & height, const AVPixelFormat & avDeviceFormat)
+  explicit MJPEG2RGB(const format_arguments_t & args = format_arguments_t())
   : pixel_format_base(
       "mjpeg2rgb",
       V4L2_PIX_FMT_MJPEG,
@@ -103,18 +102,18 @@ public:
 
     m_avcodec_context = avcodec_alloc_context3(m_avcodec);
 
-    m_avframe_device->width = width;
-    m_avframe_device->height = height;
+    m_avframe_device->width = args.width;
+    m_avframe_device->height = args.height;
     m_avframe_device->format = AV_PIX_FMT_YUV422P;
-    m_avframe_device->format = avDeviceFormat;
+    m_avframe_device->format = formats::get_av_pixel_format_from_string(args.av_device_format_str);
 
-    m_avframe_rgb->width = width;
-    m_avframe_rgb->height = height;
+    m_avframe_rgb->width = args.width;
+    m_avframe_rgb->height = args.height;
     m_avframe_rgb->format = AV_PIX_FMT_RGB24;
 
     m_sws_context = sws_getContext(
-      width, height, (AVPixelFormat)m_avframe_device->format,
-      width, height, (AVPixelFormat)m_avframe_rgb->format, SWS_FAST_BILINEAR,
+      args.width, args.height, (AVPixelFormat)m_avframe_device->format,
+      args.width, args.height, (AVPixelFormat)m_avframe_rgb->format, SWS_FAST_BILINEAR,
       NULL, NULL, NULL);
 
     // Suppress warnings from ffmpeg libraries to avoid spamming the console
@@ -122,8 +121,8 @@ public:
     av_log_set_flags(AV_LOG_SKIP_REPEATED);
     // av_log_set_flags(AV_LOG_PRINT_LEVEL);
 
-    m_avcodec_context->width = width;
-    m_avcodec_context->height = height;
+    m_avcodec_context->width = args.width;
+    m_avcodec_context->height = args.height;
     m_avcodec_context->pix_fmt = (AVPixelFormat)m_avframe_device->format;
     m_avcodec_context->codec_type = AVMEDIA_TYPE_VIDEO;
 

--- a/include/usb_cam/formats/mono.hpp
+++ b/include/usb_cam/formats/mono.hpp
@@ -44,7 +44,7 @@ namespace formats
 class MONO8 : public pixel_format_base
 {
 public:
-  MONO8()
+  explicit MONO8(const format_arguments_t & args = format_arguments_t())
   : pixel_format_base(
       "mono8",
       V4L2_PIX_FMT_GREY,
@@ -52,14 +52,16 @@ public:
       1,
       8,
       false)
-  {}
+  {
+    (void)args;
+  }
 };
 
 
 class MONO16 : public pixel_format_base
 {
 public:
-  MONO16()
+  explicit MONO16(const format_arguments_t & args = format_arguments_t())
   : pixel_format_base(
       "mono16",
       V4L2_PIX_FMT_Y16,
@@ -67,7 +69,9 @@ public:
       1,
       16,
       false)
-  {}
+  {
+    (void)args;
+  }
 };
 
 
@@ -75,7 +79,7 @@ public:
 class Y102MONO8 : public pixel_format_base
 {
 public:
-  explicit Y102MONO8(const int & number_of_pixels)
+  explicit Y102MONO8(const format_arguments_t & args = format_arguments_t())
   : pixel_format_base(
       "y102mono8",
       V4L2_PIX_FMT_Y10,
@@ -83,7 +87,7 @@ public:
       1,
       8,
       true),
-    m_number_of_pixels(number_of_pixels)
+    m_number_of_pixels(args.pixels)
   {}
 
   /// @brief Convert a Y10 (MONO10) image to MONO8

--- a/include/usb_cam/formats/pixel_format_base.hpp
+++ b/include/usb_cam/formats/pixel_format_base.hpp
@@ -84,7 +84,7 @@ public:
 
   /// @brief String value of V4L2 capture pixel format
   /// @return std::string V4L2 capture pixel format
-  inline std::string v4l2_str() { return usb_cam::conversions::FCC2S(m_v4l2); }
+  inline std::string v4l2_str() {return usb_cam::conversions::FCC2S(m_v4l2);}
 
   /// @brief Name of output pixel (encoding) format to ROS
   /// @return

--- a/include/usb_cam/formats/pixel_format_base.hpp
+++ b/include/usb_cam/formats/pixel_format_base.hpp
@@ -43,6 +43,21 @@ namespace formats
 {
 
 
+/// @brief Helper structure to standardize all pixel_format_base
+/// constructors, so that they all have the same argument type.
+///
+/// This should also be easily extendable in the future if we need to add additional
+/// arguments for future pixel format(s) that are added.
+typedef struct
+{
+  std::string name = "";
+  int width = 640;
+  int height = 480;
+  size_t pixels = 640 * 480;
+  std::string av_device_format_str = "AV_PIX_FMT_YUV422P";
+} format_arguments_t;
+
+
 /// @brief Base pixel format class. Provide all necessary information for converting between
 /// V4L2 and ROS formats. Meant to be overridden if conversion function is required.
 class pixel_format_base

--- a/include/usb_cam/formats/pixel_format_base.hpp
+++ b/include/usb_cam/formats/pixel_format_base.hpp
@@ -35,7 +35,7 @@
 #include "linux/videodev2.h"
 
 #include "usb_cam/constants.hpp"
-
+#include "usb_cam/conversions.hpp"
 
 namespace usb_cam
 {
@@ -79,8 +79,12 @@ public:
   inline std::string name() {return m_name;}
 
   /// @brief Integer value of V4L2 capture pixel format
-  /// @return
+  /// @return uint32_t V4L2 capture pixel format
   inline uint32_t v4l2() {return m_v4l2;}
+
+  /// @brief String value of V4L2 capture pixel format
+  /// @return std::string V4L2 capture pixel format
+  inline std::string v4l2_str() { return usb_cam::conversions::FCC2S(m_v4l2); }
 
   /// @brief Name of output pixel (encoding) format to ROS
   /// @return

--- a/include/usb_cam/formats/rgb.hpp
+++ b/include/usb_cam/formats/rgb.hpp
@@ -44,7 +44,7 @@ namespace formats
 class RGB8 : public pixel_format_base
 {
 public:
-  RGB8()
+  explicit RGB8(const format_arguments_t & args = format_arguments_t())
   : pixel_format_base(
       "rgb8",
       V4L2_PIX_FMT_RGB332,
@@ -52,7 +52,9 @@ public:
       3,
       8,
       false)
-  {}
+  {
+    (void)args;
+  }
 };
 
 }  // namespace formats

--- a/include/usb_cam/formats/uyvy.hpp
+++ b/include/usb_cam/formats/uyvy.hpp
@@ -44,7 +44,7 @@ namespace formats
 class UYVY : public pixel_format_base
 {
 public:
-  UYVY()
+  explicit UYVY(const format_arguments_t & args = format_arguments_t())
   : pixel_format_base(
       "uyvy",
       V4L2_PIX_FMT_UYVY,
@@ -52,14 +52,16 @@ public:
       2,
       8,
       false)
-  {}
+  {
+    (void)args;
+  }
 };
 
 
 class UYVY2RGB : public pixel_format_base
 {
 public:
-  explicit UYVY2RGB(const int & number_of_pixels)
+  explicit UYVY2RGB(const format_arguments_t & args = format_arguments_t())
   : pixel_format_base(
       "uyvy2rgb",
       V4L2_PIX_FMT_UYVY,
@@ -67,7 +69,7 @@ public:
       2,
       8,
       true),
-    m_number_of_pixels(number_of_pixels)
+    m_number_of_pixels(args.pixels)
   {}
 
   /// @brief In this format each four bytes is two pixels.

--- a/include/usb_cam/formats/yuyv.hpp
+++ b/include/usb_cam/formats/yuyv.hpp
@@ -44,7 +44,7 @@ namespace formats
 class YUYV : public pixel_format_base
 {
 public:
-  YUYV()
+  explicit YUYV(const format_arguments_t & args = format_arguments_t())
   : pixel_format_base(
       "yuyv",
       V4L2_PIX_FMT_YUYV,
@@ -52,14 +52,16 @@ public:
       2,
       8,
       false)
-  {}
+  {
+    (void)args;
+  }
 };
 
 
 class YUYV2RGB : public pixel_format_base
 {
 public:
-  explicit YUYV2RGB(const int & number_of_pixels)
+  explicit YUYV2RGB(const format_arguments_t & args = format_arguments_t())
   : pixel_format_base(
       "yuyv2rgb",
       V4L2_PIX_FMT_YUYV,
@@ -67,7 +69,7 @@ public:
       3,
       8,
       true),
-    m_number_of_pixels(number_of_pixels)
+    m_number_of_pixels(args.pixels)
   {}
 
   /// @brief In this format each four bytes is two pixels.

--- a/include/usb_cam/utils.hpp
+++ b/include/usb_cam/utils.hpp
@@ -46,15 +46,12 @@ extern "C" {
 #include "linux/videodev2.h"
 
 #include "usb_cam/constants.hpp"
-#include "usb_cam/formats/pixel_format_base.hpp"
 
 
 namespace usb_cam
 {
 namespace utils
 {
-
-using usb_cam::formats::pixel_format_base;
 
 
 /// @brief Read more on IO methods here: https://lwn.net/Articles/240667/

--- a/src/ros2/usb_cam_node.cpp
+++ b/src/ros2/usb_cam_node.cpp
@@ -189,19 +189,9 @@ void UsbCamNode::init()
     rclcpp::shutdown();
     return;
   }
+
   // configure the camera
   m_camera->configure(m_parameters, io_method);
-
-  RCLCPP_INFO(this->get_logger(), "This devices supproted formats:");
-  for (auto fmt : m_camera->supported_formats()) {
-    RCLCPP_INFO(
-      this->get_logger(),
-      "\t%s: %d x %d (%d Hz)",
-      fmt.format.description,
-      fmt.v4l2_fmt.width,
-      fmt.v4l2_fmt.height,
-      fmt.v4l2_fmt.discrete.denominator / fmt.v4l2_fmt.discrete.numerator);
-  }
 
   set_v4l2_params();
 


### PR DESCRIPTION
- Closes #263 
- driver now checks if given pixel format is:
    1. supproted by this driver and
    2. supported by the specified device
 
Throws a verbose error for now instead of silently falling back to some random format. In the future we might be able to add some logic to auto-determine the "best" available pixel format and fall back to that

This also lets us clean up the `set_pixel_format` logic to be much more maintainable and easier to understand.