### PR TITLE
Resolve Symlinks

### DIFF
--- a/src/ros2/usb_cam_node.cpp
+++ b/src/ros2/usb_cam_node.cpp
@@ -121,8 +121,9 @@ void UsbCamNode::service_capture(
   }
 }
 
-std::string resolve_device_path(const std::string& path){
-  if(std::filesystem::is_symlink(path)){
+std::string resolve_device_path(const std::string & path)
+{
+  if (std::filesystem::is_symlink(path)) {
     // For some reason read_symlink only returns videox
     return "/dev/" + std::string(std::filesystem::read_symlink(path));
   }

--- a/src/ros2/usb_cam_node.cpp
+++ b/src/ros2/usb_cam_node.cpp
@@ -123,7 +123,7 @@ void UsbCamNode::service_capture(
 
 std::string resolve_device_path(const std::string& path){
   if(std::filesystem::is_symlink(path)){
-    //For some reason read_symlink only returns videox
+    // For some reason read_symlink only returns videox
     return "/dev/" + std::string(std::filesystem::read_symlink(path));
   }
   return path;

--- a/src/ros2/usb_cam_node.cpp
+++ b/src/ros2/usb_cam_node.cpp
@@ -30,7 +30,7 @@
 #include <sstream>
 #include <string>
 #include <vector>
-
+#include <filesystem>
 #include "usb_cam/usb_cam_node.hpp"
 #include "usb_cam/utils.hpp"
 
@@ -119,6 +119,14 @@ void UsbCamNode::service_capture(
     m_camera->stop_capturing();
     response->message = "Stop Capturing";
   }
+}
+
+std::string resolve_device_path(const std::string& path){
+  if(std::filesystem::is_symlink(path)){
+    //For some reason read_symlink only returns videox
+    return "/dev/" + std::string(std::filesystem::read_symlink(path));
+  }
+  return path;
 }
 
 void UsbCamNode::init()
@@ -246,7 +254,7 @@ void UsbCamNode::assign_params(const std::vector<rclcpp::Parameter> & parameters
     } else if (parameter.get_name() == "av_device_format") {
       m_parameters.av_device_format = parameter.value_to_string();
     } else if (parameter.get_name() == "video_device") {
-      m_parameters.device_name = parameter.value_to_string();
+      m_parameters.device_name = resolve_device_path(parameter.value_to_string());
     } else if (parameter.get_name() == "brightness") {
       m_parameters.brightness = parameter.as_int();
     } else if (parameter.get_name() == "contrast") {


### PR DESCRIPTION
See #310 

EDIT:
This PR solves only half of the problem. In order to fully solve the problem I think we should not do any assumptions on how the video device is actually called.

The reason for this edit is that we usually work with docker containers. We only mount our /dev/camerax devices into the container and not the /dev/videox. Additionally if mounted via `--device` a symlink in dev becomes a normal file entry in dev in the container. 

This PR at least solves the problem if /dev/videox exists and /dev/camerax (or whatever the symlink is called) exists in /dev.