### PR TITLE
Switch to a const AVCodec *.

### DIFF
--- a/include/usb_cam/formats/mjpeg.hpp
+++ b/include/usb_cam/formats/mjpeg.hpp
@@ -233,7 +233,7 @@ private:
     std::cerr << m_averror_str << std::endl;
   }
 
-  AVCodec * m_avcodec;
+  const AVCodec * m_avcodec;
   AVCodecContext * m_avcodec_context;
   AVCodecParserContext * m_avparser;
   AVFrame * m_avframe_device;


### PR DESCRIPTION
This is because newer versions of avcodec return a const AVCodec *.

This should fix the build on Ubuntu 24.04, like in https://build.ros2.org/view/Rbin_uN64/job/Rbin_uN64__usb_cam__ubuntu_noble_amd64__binary/ .  I also compile tested it on Ubuntu 22.04, and it worked find there as well.