### PR TITLE
Remove deprecared/unneeded avcodec_close()

### DIFF
--- a/include/usb_cam/formats/mjpeg.hpp
+++ b/include/usb_cam/formats/mjpeg.hpp
@@ -164,7 +164,6 @@ public:
       free(m_avoptions);
     }
     if (m_avcodec_context) {
-      avcodec_close(m_avcodec_context);
       avcodec_free_context(&m_avcodec_context);
     }
     if (m_avframe_device) {


### PR DESCRIPTION
From [docs](https://ffmpeg.org/doxygen/trunk/deprecated.html) see that this function call is not needed:

"Do not use this function. Use avcodec_free_context() to destroy a codec context (either open or closed). Opening and closing a codec context multiple times is not supported anymore – use multiple codec contexts instead."

avcodec_free_context is already called.

Fixes `error: ‘int avcodec_close(AVCodecContext*)’ is deprecated [-Werror=deprecated-declarations]` for my builds.