### PR TITLE
Remove undocumented pix_fmt breaking new builds

### DIFF
--- a/include/usb_cam/formats/av_pixel_format_helper.hpp
+++ b/include/usb_cam/formats/av_pixel_format_helper.hpp
@@ -743,12 +743,6 @@ const std::unordered_map<std::string, AVPixelFormat> STR_2_AVPIXFMT = {
                                                                       ///< 16-bit samples,
                                                                       ///< big-endian
 
-
-  {stringify(AV_PIX_FMT_XVMC), AV_PIX_FMT_XVMC},                      ///< XVideo Motion
-                                                                      ///< Acceleration via common
-                                                                      ///< packet passing
-
-
   {stringify(AV_PIX_FMT_YUV440P10LE), AV_PIX_FMT_YUV440P10LE},        ///< planar YUV 4:4:0,20bpp,
                                                                       ///< (1 Cr & Cb sample per
                                                                       ///< 1x2 Y samples),


### PR DESCRIPTION
This no longer exists in ffmpeg trunk. I see that is exists in older versions, such as 2.7. However, even in those versions, it is not documented.

There are similarly named and now document formats such as AV_PIX_FMT_XV30 and AV_PIX_FMT_XV60, which should probably be supported instead, but I will not add these in this PR. 

This solves `include/usb_cam/formats/av_pixel_format_helper.hpp:747:32: error: ‘AV_PIX_FMT_XVMC’ was not declared in this scope; did you mean ‘AV_PIX_FMT_XV30’?` in my build.