### PR TITLE
Add missing pkg-config build dependency.

### DIFF
--- a/package.xml
+++ b/package.xml
@@ -15,7 +15,8 @@
 
   <!-- Required so ROS build farms properly set ROS_VERSION -->
   <build_depend>ros_environment</build_depend>
-
+  
+  <buildtool_depend>pkg-config</buildtool_depend>
   <buildtool_depend condition="$ROS_VERSION == 1">catkin</buildtool_depend>
 
   <buildtool_depend condition="$ROS_VERSION == 2">ament_cmake_auto</buildtool_depend>


### PR DESCRIPTION
Downstream project nix-ros-overlay cannot build this project without `pkg-config` being included in its list of build dependencies: https://github.com/lopsided98/nix-ros-overlay/pull/517