### PR TITLE
Read images from buffer at normal speed, adjust publish rate via param

### DIFF
--- a/include/usb_cam/usb_cam_node.hpp
+++ b/include/usb_cam/usb_cam_node.hpp
@@ -66,6 +66,7 @@ public:
   void assign_params(const std::vector<rclcpp::Parameter> & parameters);
   void set_v4l2_params();
   void update();
+  void publish();
   bool take_and_send_image();
   bool take_and_send_image_mjpeg();
 
@@ -91,6 +92,7 @@ public:
   std::shared_ptr<camera_info_manager::CameraInfoManager> m_camera_info;
 
   rclcpp::TimerBase::SharedPtr m_timer;
+  rclcpp::TimerBase::SharedPtr m_publish_timer;
 
   rclcpp::Service<std_srvs::srv::SetBool>::SharedPtr m_service_capture;
   rclcpp::node_interfaces::OnSetParametersCallbackHandle::SharedPtr m_parameters_callback_handle;

--- a/src/usb_cam.cpp
+++ b/src/usb_cam.cpp
@@ -524,7 +524,7 @@ void UsbCam::configure(
   m_image.pixel_format = set_pixel_format(parameters);
   m_image.set_bytes_per_line();
   m_image.set_size_in_bytes();
-  m_framerate = parameters.framerate;
+  m_framerate = set_frame_rate(parameters);
 
   init_device();
 }


### PR DESCRIPTION
related to #319

When receiving camera images via V4L,
it is unclear whether images accumulate in the buffer,
but if the framerate parameter is set lower than the default, the usb_cam node retrieves old images, causing noticeable delay.

To address this, image acquisition from V4L now runs at the default rate, while only the ROS2 topic publishing rate is adjusted via the framerate parameter.