### PR TITLE
[ros-o][jammy] install libv4l_driver.so

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -120,7 +120,7 @@ target_link_libraries(usb_cam_node
 
 # Installation scenario
 # Executables and libraries
-install(TARGETS ${PROJECT_NAME}_node ${PROJECT_NAME}
+install(TARGETS ${PROJECT_NAME}_node v4l_driver ${PROJECT_NAME}
     RUNTIME DESTINATION ${CATKIN_PACKAGE_BIN_DESTINATION}
     LIBRARY DESTINATION ${CATKIN_PACKAGE_LIB_DESTINATION}
 )


### PR DESCRIPTION
In ros-o, we encountered the issue

```
❯ rosrun usb_cam usb_cam_node
/opt/ros/one/lib/usb_cam/usb_cam_node: error while loading shared libraries: libv4l_driver.so: cannot open shared object file: No such file or directory
```

It seems that `libv4l_driver.so` is not installed when built as debian package in ros-o / Ubuntu 22.04. 

```
❯ ldd usb_cam_node
        linux-vdso.so.1 (0x00007fff0ada1000)
        libusb_cam.so => /opt/ros/one/lib/libusb_cam.so (0x00007efe74b77000)
        libroscpp.so => /opt/ros/one/lib/libroscpp.so (0x00007efe74a5d000)
        libstdc++.so.6 => /lib/x86_64-linux-gnu/libstdc++.so.6 (0x00007efe7480d000)
        libgcc_s.so.1 => /lib/x86_64-linux-gnu/libgcc_s.so.1 (0x00007efe747ed000)
        libc.so.6 => /lib/x86_64-linux-gnu/libc.so.6 (0x00007efe745c4000)
        libimage_transport.so => /opt/ros/one/lib/libimage_transport.so (0x00007efe7455a000)
        libcamera_info_manager.so => /opt/ros/one/lib/libcamera_info_manager.so (0x00007efe7453c000)
        librosconsole.so => /opt/ros/one/lib/librosconsole.so (0x00007efe744fe000)
        libroscpp_serialization.so => /opt/ros/one/lib/libroscpp_serialization.so (0x00007efe744f9000)
        librostime.so => /opt/ros/one/lib/librostime.so (0x00007efe744de000)
        libv4l_driver.so => not found
        libxmlrpcpp.so => /opt/ros/one/lib/libxmlrpcpp.so (0x00007efe744bb000)
        libcpp_common.so => /opt/ros/one/lib/libcpp_common.so (0x00007efe744b0000)
        libboost_thread.so.1.74.0 => /lib/x86_64-linux-gnu/libboost_thread.so.1.74.0 (0x00007efe7448e000)
        libboost_chrono.so.1.74.0 => /lib/x86_64-linux-gnu/libboost_chrono.so.1.74.0 (0x00007efe74483000)
        libboost_filesystem.so.1.74.0 => /lib/x86_64-linux-gnu/libboost_filesystem.so.1.74.0 (0x00007efe74463000)
        libm.so.6 => /lib/x86_64-linux-gnu/libm.so.6 (0x00007efe7437c000)
        /lib64/ld-linux-x86-64.so.2 (0x00007efe74b9e000)
        libmessage_filters.so => /opt/ros/one/lib/libmessage_filters.so (0x00007efe74374000)
        libclass_loader.so => /opt/ros/one/lib/libclass_loader.so (0x00007efe74353000)
        libroslib.so => /opt/ros/one/lib/libroslib.so (0x00007efe74342000)
        libtinyxml2.so.9 => /lib/x86_64-linux-gnu/libtinyxml2.so.9 (0x00007efe7432a000)
        libconsole_bridge.so.1.0 => /lib/x86_64-linux-gnu/libconsole_bridge.so.1.0 (0x00007efe74324000)
        libcamera_calibration_parsers.so => /opt/ros/one/lib/libcamera_calibration_parsers.so (0x00007efe742fb000)
        librosconsole_log4cxx.so => /opt/ros/one/lib/librosconsole_log4cxx.so (0x00007efe742e4000)
        librosconsole_backend_interface.so => /opt/ros/one/lib/librosconsole_backend_interface.so (0x00007efe742df000)
        liblog4cxx.so.12 => /lib/x86_64-linux-gnu/liblog4cxx.so.12 (0x00007efe74180000)
        libboost_regex.so.1.74.0 => /lib/x86_64-linux-gnu/libboost_regex.so.1.74.0 (0x00007efe7408d000)
        libPocoFoundation.so.80 => /lib/x86_64-linux-gnu/libPocoFoundation.so.80 (0x00007efe73ee2000)
        librospack.so => /opt/ros/one/lib/librospack.so (0x00007efe73ea5000)
        libyaml-cpp.so.0.7 => /lib/x86_64-linux-gnu/libyaml-cpp.so.0.7 (0x00007efe73e66000)
        libaprutil-1.so.0 => /lib/x86_64-linux-gnu/libaprutil-1.so.0 (0x00007efe73e38000)
        libapr-1.so.0 => /lib/x86_64-linux-gnu/libapr-1.so.0 (0x00007efe73dfb000)
        libicui18n.so.70 => /lib/x86_64-linux-gnu/libicui18n.so.70 (0x00007efe73acc000)
        libicuuc.so.70 => /lib/x86_64-linux-gnu/libicuuc.so.70 (0x00007efe738cf000)
        libpcre.so.3 => /lib/x86_64-linux-gnu/libpcre.so.3 (0x00007efe73859000)
        libz.so.1 => /lib/x86_64-linux-gnu/libz.so.1 (0x00007efe7383d000)
        libboost_program_options.so.1.74.0 => /lib/x86_64-linux-gnu/libboost_program_options.so.1.74.0 (0x00007efe737f8000)
        libpython3.10.so.1.0 => /lib/x86_64-linux-gnu/libpython3.10.so.1.0 (0x00007efe73221000)
        libcrypt.so.1 => /lib/x86_64-linux-gnu/libcrypt.so.1 (0x00007efe731e5000)
        libexpat.so.1 => /lib/x86_64-linux-gnu/libexpat.so.1 (0x00007efe731b4000)
        libuuid.so.1 => /lib/x86_64-linux-gnu/libuuid.so.1 (0x00007efe731ab000)
        libicudata.so.70 => /lib/x86_64-linux-gnu/libicudata.so.70 (0x00007efe7158d000)
```

I installed ros-one with https://ros.packages.techfak.net/ .

I confirmed that this patch works well with trying generating .deb and installing using bloom-generate.