### PR TITLE
Option to skip device check

### DIFF
--- a/include/usb_cam/usb_cam.hpp
+++ b/include/usb_cam/usb_cam.hpp
@@ -125,6 +125,8 @@ typedef struct parameters_t
   bool auto_white_balance;
   bool autoexposure;
   bool autofocus;
+  // When true, UsbCamNode will not validate the device exists in available V4L2 devices
+  bool skip_device_check;
 
   parameters_t()
 // *INDENT-OFF*
@@ -148,7 +150,8 @@ typedef struct parameters_t
     focus(-1),
     auto_white_balance(true),
     autoexposure(true),
-    autofocus(false)
+    autofocus(false),
+    skip_device_check(false)
   {
   }
 // *INDENT-ON*


### PR DESCRIPTION
Some video devices are mapped by udev, for example /dev/cam1, /dev/cam2.  The rules are specific to each camera and are deterministic.  /dev/video* is random based on the order the devices are plugged in.  I want to be able to use the fixed mappings, but these checks are preventing that.
