### PR TITLE
Fix raw_mjpeg passthrough for compressed image publishing

### DIFF
--- a/src/usb_cam_node.cpp
+++ b/src/usb_cam_node.cpp
@@ -176,9 +176,9 @@ void UsbCamNode::init()
     return;
   }
 
-  // if pixel format is equal to 'mjpeg', i.e. raw mjpeg stream, initialize compressed image message
+  // if pixel format is equal to 'raw_mjpeg', i.e. raw mjpeg stream, initialize compressed image message
   // and publisher
-  if (m_parameters.pixel_format_name == "mjpeg") {
+  if (m_parameters.pixel_format_name == "raw_mjpeg") {
     m_compressed_img_msg.reset(new sensor_msgs::msg::CompressedImage());
     m_compressed_img_msg->header.frame_id = m_parameters.frame_id;
     m_compressed_image_publisher =
@@ -430,7 +430,7 @@ void UsbCamNode::update()
     // If the camera exposure longer higher than the framerate period
     // then that caps the framerate.
     // auto t0 = now();
-    bool isSuccessful = (m_parameters.pixel_format_name == "mjpeg") ?
+    bool isSuccessful = (m_parameters.pixel_format_name == "raw_mjpeg") ?
       take_and_send_image_mjpeg() :
       take_and_send_image();
     if (!isSuccessful) {


### PR DESCRIPTION
Change pixel format check from 'mjpeg' to 'raw_mjpeg' to enable direct MJPEG passthrough to compressed topic without decode/re-encode.

This allows the driver to publish raw MJPEG data directly on the /image_raw/compressed topic, avoiding unnecessary CPU usage from decoding to YUV and re-encoding to JPEG.

Fixes: https://github.com/ros-drivers/usb_cam/issues/346