### PR TITLE
Remove unused properties in `UsbCam` class

### DIFF
--- a/include/usb_cam/formats/mjpeg.hpp
+++ b/include/usb_cam/formats/mjpeg.hpp
@@ -41,6 +41,7 @@
 
 extern "C" {
 #define __STDC_CONSTANT_MACROS  // Required for libavutil
+#include <libavcodec/avcodec.h>
 #include "libavutil/imgutils.h"
 #include "libavformat/avformat.h"
 #include "libavutil/error.h"
@@ -49,7 +50,6 @@ extern "C" {
 #include "libswscale/swscale.h"
 }
 
-#include "usb_cam/usb_cam.hpp"
 #include "usb_cam/formats/pixel_format_base.hpp"
 #include "usb_cam/formats/utils.hpp"
 #include "usb_cam/formats/av_pixel_format_helper.hpp"

--- a/include/usb_cam/usb_cam.hpp
+++ b/include/usb_cam/usb_cam.hpp
@@ -30,11 +30,6 @@
 #ifndef USB_CAM__USB_CAM_HPP_
 #define USB_CAM__USB_CAM_HPP_
 
-extern "C" {
-#include <libavcodec/avcodec.h>
-#include <linux/videodev2.h>
-}
-
 #include <chrono>
 #include <memory>
 #include <algorithm>
@@ -290,26 +285,6 @@ public:
     return m_number_of_buffers;
   }
 
-  inline AVCodec * get_avcodec()
-  {
-    return m_avcodec;
-  }
-
-  inline AVDictionary * get_avoptions()
-  {
-    return m_avoptions;
-  }
-
-  inline AVCodecContext * get_avcodec_context()
-  {
-    return m_avcodec_context;
-  }
-
-  inline AVFrame * get_avframe()
-  {
-    return m_avframe;
-  }
-
   inline bool is_capturing()
   {
     return m_is_capturing;
@@ -421,11 +396,6 @@ private:
   unsigned int m_number_of_buffers;
   std::shared_ptr<usb_cam::utils::buffer[]> m_buffers;
   image_t m_image;
-
-  AVFrame * m_avframe;
-  AVCodec * m_avcodec;
-  AVDictionary * m_avoptions;
-  AVCodecContext * m_avcodec_context;
 
   bool m_is_capturing;
   int m_framerate;

--- a/src/usb_cam.cpp
+++ b/src/usb_cam.cpp
@@ -60,8 +60,7 @@ using utils::io_method_t;
 UsbCam::UsbCam()
 : m_device_name(), m_io(io_method_t::IO_METHOD_MMAP), m_fd(-1),
   m_number_of_buffers(4), m_buffers(new usb_cam::utils::buffer[m_number_of_buffers]), m_image(),
-  m_avframe(NULL), m_avcodec(NULL), m_avoptions(NULL),
-  m_avcodec_context(NULL), m_is_capturing(false), m_framerate(0),
+  m_is_capturing(false), m_framerate(0),
   m_epoch_time_shift_us(usb_cam::utils::get_epoch_time_shift_us()), m_supported_formats()
 {}
 


### PR DESCRIPTION
This pull request removed the unused `m_avframe`, `m_avcodec`, `m_avoptions`, and `m_avcodec_context` properties from the `UsbCam` class.