### PR TITLE
Fix cpplint and crustify errors 

### DIFF
--- a/include/usb_cam/formats/mjpeg.hpp
+++ b/include/usb_cam/formats/mjpeg.hpp
@@ -36,19 +36,19 @@
 /// https://www.ffmpeg.org/doxygen/4.0/decode__video_8c_source.html
 ///
 
-#include <iostream>
-
 
 extern "C" {
 #define __STDC_CONSTANT_MACROS  // Required for libavutil
 #include <libavcodec/avcodec.h>
-#include "libavutil/imgutils.h"
-#include "libavformat/avformat.h"
-#include "libavutil/error.h"
-#include "libavutil/log.h"
-#include "linux/videodev2.h"
-#include "libswscale/swscale.h"
+#include <libavutil/imgutils.h>
+#include <libavformat/avformat.h>
+#include <libavutil/error.h>
+#include <libavutil/log.h>
+#include <linux/videodev2.h>
+#include <libswscale/swscale.h>
 }
+
+#include <iostream>
 
 #include "usb_cam/formats/pixel_format_base.hpp"
 #include "usb_cam/formats/utils.hpp"

--- a/include/usb_cam/usb_cam.hpp
+++ b/include/usb_cam/usb_cam.hpp
@@ -416,7 +416,8 @@ public:
     for (auto fmt : this->supported_formats()) {
       if (fmt.v4l2_fmt.width == static_cast<size_t>(parameters.image_width) &&
         fmt.v4l2_fmt.height == static_cast<size_t>(parameters.image_height) &&
-        fmt.v4l2_fmt.pixel_format == found_driver_format->v4l2()) {
+        fmt.v4l2_fmt.pixel_format == found_driver_format->v4l2())
+      {
         return fmt.v4l2_fmt.discrete.denominator / fmt.v4l2_fmt.discrete.numerator;
       }
     }

--- a/src/usb_cam_node.cpp
+++ b/src/usb_cam_node.cpp
@@ -224,7 +224,8 @@ void UsbCamNode::init()
   if (static_cast<size_t>(m_parameters.framerate) > frame_rate) {
     RCLCPP_WARN_STREAM(
       this->get_logger(),
-      "Desired framerate " << m_parameters.framerate << " is higher than the camera's capability " <<
+      "Desired framerate " << m_parameters.framerate <<
+        " is higher than the camera's capability " <<
         frame_rate << " fps");
     m_parameters.framerate = frame_rate;
   }


### PR DESCRIPTION
It seems the CI currently fails because of errors produced by ament_cpplint
In particular it seems to be unsatisfied by the include order of system and local headers in `include/usb_cam/formats/mjpeg.hpp`.

I changed all external C headers to system headers (I think this should be the case anyway?) 
I moved the cpp header include of iostream after them. Now ament_cpplint seems to be satisfied.
Also, applied minor code refomratting as porposed by crustify.

fixes: #382
