### PR TITLE
fix(launch): resolve Pydantic v2 compatibility and update build instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,14 +37,41 @@ git clone https://github.com/ros-drivers/usb_cam.git
 
 Or click on the green "Download zip" button on the repo's github webpage.
 
-Once downloaded and ensuring you have sourced your ROS 2 underlay, go ahead and install the dependencies:
+### 1. Source ROS 2 Underlay
+
+Source your ROS 2 installation to set up your environment (replace `jazzy` with your installed ROS 2 version if different):
+
+```shell
+source /opt/ros/jazzy/setup.bash
+```
+
+### 2. Install Dependencies
+
+You can install the dependencies automatically using `rosdep`. If you don't have `rosdep` installed, install and initialize it first:
+
+```shell
+# Install rosdep if missing
+sudo apt-get update
+sudo apt-get install python3-rosdep
+sudo rosdep init
+rosdep update
+```
+
+Then, install the package dependencies from the root of your workspace:
 
 ```shell
 cd /path/to/colcon_ws
-rosdep install --from-paths src --ignore-src -y
+rosdep install --from-paths src --ignore-src -y --rosdistro ${ROS_DISTRO}
 ```
 
-From there you should have all the necessary dependencies installed to compile the `usb_cam` package:
+*(Optional) If you prefer to install the dependencies manually without rosdep:*
+```shell
+sudo apt-get install ros-${ROS_DISTRO}-camera-info-manager v4l-utils python3-pydantic
+```
+
+### 3. Build the Package
+
+After the dependencies are successfully installed, build the workspace:
 
 ```shell
 cd /path/to/colcon_ws

--- a/launch/camera_config.py
+++ b/launch/camera_config.py
@@ -31,7 +31,10 @@ from pathlib import Path
 from typing import List, Optional
 
 from ament_index_python.packages import get_package_share_directory
-from pydantic import BaseModel, root_validator, validator
+try:
+    from pydantic.v1 import BaseModel, root_validator, validator
+except ImportError:
+    from pydantic import BaseModel, root_validator, validator
 
 USB_CAM_DIR = get_package_share_directory('usb_cam')
 


### PR DESCRIPTION
### Description

This Pull Request addresses two main issues related to building and launching the `usb_cam` package on newer environments (specifically ROS 2 Jazzy on Ubuntu 24.04):

1. **Pydantic v2 Compatibility**:
    - ROS 2 Jazzy uses Pydantic v2, which deprecates/breaks the older Pydantic v1 validator syntax (`@root_validator`) used in `launch/camera_config.py`.
    - Updated the imports in `launch/camera_config.py` to import from `pydantic.v1` with a fallback to `pydantic`. This maintains backward compatibility with ROS 2 Humble/Pydantic v1 while fixing the crash on ROS 2 Jazzy.

2. **Build and Sourcing Documentation**:
    - Updated `README.md` to explicitly guide users through sourcing their ROS 2 installation.
    - Added steps for installing and initializing `rosdep` if it is missing on the system.
    - Updated dependency installation commands to dynamically use `${ROS_DISTRO}` for convenience.

### Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] Documentation update

### How Has This Been Tested?

- Tested building under ROS 2 Jazzy with a clean workspace (`colcon build`).
- Verified that `ros2 launch usb_cam camera.launch.py` starts correctly without throwing Pydantic-related Python exceptions.