### PR TITLE
Update ROS 2 API usage in usb_cam_node

### DIFF
--- a/src/usb_cam_node.cpp
+++ b/src/usb_cam_node.cpp
@@ -45,8 +45,8 @@ UsbCamNode::UsbCamNode(const rclcpp::NodeOptions & node_options)
   m_image_msg(new sensor_msgs::msg::Image()),
   m_compressed_img_msg(nullptr),
   m_image_publisher(std::make_shared<image_transport::CameraPublisher>(
-      image_transport::create_camera_publisher(this, BASE_TOPIC_NAME,
-      rclcpp::QoS {100}.get_rmw_qos_profile()))),
+      image_transport::create_camera_publisher(
+        *this, BASE_TOPIC_NAME, rclcpp::QoS {100}))),
   m_compressed_image_publisher(nullptr),
   m_compressed_cam_info_publisher(nullptr),
   m_parameters(),
@@ -151,7 +151,11 @@ void UsbCamNode::init()
   // load the camera info
   m_camera_info.reset(
     new camera_info_manager::CameraInfoManager(
-      this, m_parameters.camera_name, m_parameters.camera_info_url));
+      this->get_node_base_interface(),
+      this->get_node_services_interface(),
+      this->get_node_logging_interface(),
+      m_parameters.camera_name,
+      m_parameters.camera_info_url));
   // check for default camera info
   if (!m_camera_info->isCalibrated()) {
     m_camera_info->setCameraName(m_parameters.device_name);


### PR DESCRIPTION
This is part of an effort to contribute RoboStack downstream patches back upstream.

Origin: `patch/ros-rolling-usb-cam.patch`, authored by Daisuke Nishimatsu.

This updates two `usb_cam_node` calls to the current ROS 2 APIs used by `image_transport` and `camera_info_manager`. The RoboStack patch also includes warning-policy and FFmpeg compatibility changes, but this PR keeps the ROS 2 API compatibility changes separate.
